### PR TITLE
Feature: process sandbox

### DIFF
--- a/nodel-framework-java/src/main/java/org/nodel/Environment.java
+++ b/nodel-framework-java/src/main/java/org/nodel/Environment.java
@@ -13,6 +13,62 @@ import java.util.List;
  * Some utility methods related to the Java environment.
  */
 public class Environment {
+    
+    /**
+     * for:
+     * ManagementFactory.getRuntimeMXBean()
+     */
+    private Object _runtimeMxBean;    
+    
+    /**
+     * for:
+     * List<String> arguments = runtimeMxBean.getInputArguments();
+     */
+    private Method _getInputArgumentsMethod;
+    
+    /**
+     * for:
+     * string name = ManagementFactory.getRuntimeMXBean().getName() 
+     */
+    private Method _getNameMethod;
+    
+    /**
+     * Ensures all the late binding only occurs once.
+     */
+    private Environment() {
+        try {
+            Class<?> factoryClass = Class.forName("java.lang.management.ManagementFactory");
+            Method getRuntimeMXBeanMethod = factoryClass.getMethod("getRuntimeMXBean");
+            
+            _runtimeMxBean = getRuntimeMXBeanMethod.invoke(null, new Object[] {});
+            
+            Class<? extends Object> runtimeMxBeanClass = _runtimeMxBean.getClass();
+
+            _getInputArgumentsMethod = runtimeMxBeanClass.getMethod("getInputArguments");
+            _getInputArgumentsMethod.setAccessible(true);
+            
+            _getNameMethod = runtimeMxBeanClass.getMethod("getName");
+            _getNameMethod.setAccessible(true);
+            
+        } catch (Exception exc) {
+            // ignore
+        }
+    }
+    
+    /**
+     * (singleton)
+     */
+    private static class LazyHolder {
+        private static final Environment INSTANCE = new Environment();
+    }
+
+    /**
+     * Shared, singleton instance.
+     */
+    public static Environment instance() {
+        return LazyHolder.INSTANCE;
+    }
+    
 
     /**
      * Gets any special VM args that are used on every platform. We're looking to do this, but not all platforms 
@@ -20,30 +76,42 @@ public class Environment {
      * 
      * java.lang.management.RuntimeMXBean runtimeMxBean = java.lang.management.ManagementFactory.getRuntimeMXBean();
      * List<String> arguments = runtimeMxBean.getInputArguments();
-     * 
-     * @return
      */
-    public static List<String> getVMArgs() {
+    public List<String> getVMArgs() {
         try {
-            Class<?> factoryClass = Class.forName("java.lang.management.ManagementFactory");
-
-            Method getRuntimeMXBeanMethod = factoryClass.getMethod("getRuntimeMXBean");
-
-            Object runtimeMxBean = getRuntimeMXBeanMethod.invoke(null, new Object[] {});
+            if (_getInputArgumentsMethod == null)
+                return null;
             
-            Class<?> runtimeMxBeanClass = runtimeMxBean.getClass();
-            
-            Method getInputArgumentsMethod = runtimeMxBeanClass.getMethod("getInputArguments");
-            getInputArgumentsMethod.setAccessible(true);
-
-            Object argObj = getInputArgumentsMethod.invoke(runtimeMxBean, new Object[] {});
+            Object argObj = _getInputArgumentsMethod.invoke(_runtimeMxBean, new Object[] {});
 
             @SuppressWarnings("unchecked")
-            List<String> args = (List<String>) argObj;
+            List<String> result = (List<String>) argObj;
 
-            return args;
+            return result;
+            
         } catch (Exception exc) {
             return null;
+        }
+    }
+
+    /**
+     * In Java 7 and 8 there is no elegant way to get the current PID. This has to be done:
+     * 
+     * int result = Integer.parseInt(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);
+     */
+    public int getPID() {
+        try {
+            if (_getNameMethod == null)
+                return 0;
+
+            String name = (String) _getNameMethod.invoke(_runtimeMxBean, new Object[] {});
+
+            int result = Integer.parseInt(name.split("@")[0]);
+
+            return result;
+            
+        } catch (Exception exc) {
+            return 0;
         }
     }
 

--- a/nodel-framework-java/src/main/java/org/nodel/core/Nodel.java
+++ b/nodel-framework-java/src/main/java/org/nodel/core/Nodel.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.nodel.Environment;
 import org.nodel.Handler;
 import org.nodel.Handlers;
 import org.nodel.SimpleName;
@@ -521,13 +522,11 @@ public class Nodel {
         s_hardLinksAddresses = list;
     }
     
-	/**
-	 * Java (up to version 8) provides no way besides this crude technique to retrieve the PID of this process 
-	 */
+    /**
+     * Gets the PID of the current process.
+     */
     public static int getPID() {
-    	// TODO: don't directly bind to ManagementFactory class, rather
-    	// allow for the possibility of this failing on some platforms by using reflection
-		return Integer.parseInt(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);		
-	}    
+        return Environment.instance().getPID();
+    }
 
 }

--- a/nodel-framework-java/src/main/java/org/nodel/core/Nodel.java
+++ b/nodel-framework-java/src/main/java/org/nodel/core/Nodel.java
@@ -520,5 +520,14 @@ public class Nodel {
 
         s_hardLinksAddresses = list;
     }
+    
+	/**
+	 * Java (up to version 8) provides no way besides this crude technique to retrieve the PID of this process 
+	 */
+    public static int getPID() {
+    	// TODO: don't directly bind to ManagementFactory class, rather
+    	// allow for the possibility of this failing on some platforms by using reflection
+		return Integer.parseInt(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);		
+	}    
 
 }

--- a/nodel-framework-java/src/main/java/org/nodel/diagnostics/Diagnostics.java
+++ b/nodel-framework-java/src/main/java/org/nodel/diagnostics/Diagnostics.java
@@ -140,7 +140,7 @@ public class Diagnostics {
     
     @Value(name = "vmArgs", title = "VM arguments", desc = "The arguments supplied to this instance of the VM.")
     public List<String> vmArgs() {
-        return Environment.getVMArgs();
+        return Environment.instance().getVMArgs();
     }
     
     @Value(name = "availableProcessors", title = "Available processors", desc = "The number of available processors.")

--- a/nodel-framework-java/src/main/java/org/nodel/toolkit/ManagedProcess.java
+++ b/nodel-framework-java/src/main/java/org/nodel/toolkit/ManagedProcess.java
@@ -591,11 +591,11 @@ public class ManagedProcess implements Closeable {
             // ensure enough arguments (at least 1)
             if (origCommand == null || origCommand.size() == 0)
                 throw new RuntimeException("No launch arguments were provided.");
-
+            
             // if on Windows, use the ProcessSandbox.exe utility if it can be found
-            // (try it in current dir...)
+            // (try it in node root...)
             final String PROCESS_SANDBOX = "ProcessSandbox.exe";
-            File processSandboxFile = new File(PROCESS_SANDBOX);
+            File processSandboxFile = new File(_parentNode.getRoot(), PROCESS_SANDBOX);
             if (!processSandboxFile.exists()) {
                 // otherwise is it next to the executable we're trying to run
                 // (which might not have any path information)
@@ -604,9 +604,10 @@ public class ManagedProcess implements Closeable {
                     processSandboxFile = new File(processExe.getParent(), PROCESS_SANDBOX);
                     if (!processSandboxFile.exists())
                         processSandboxFile = null;
+                } else {
+                    // doesn't have any path information, so can't do anything
+                    processSandboxFile = null;
                 }
-            } else {
-                processSandboxFile = null;
             }
 
             List<String> command; // the command list that will be used

--- a/toolkit-util/ProcessSandbox/Properties/AssemblyInfo.cs
+++ b/toolkit-util/ProcessSandbox/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
-[assembly: AssemblyFileVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.4")]
+[assembly: AssemblyFileVersion("1.0.0.4")]
 [assembly: AssemblyDescription("(see nodel.io or github.com/museumvictoria/nodel)")]
 


### PR DESCRIPTION
In Windows environments, a process sandbox launcher can be used to ensure all children processes are cleaned and managed together regardless of a Nodel restart or child-process termination.