### PR TITLE
Add support for @lg >1200px column layouts

### DIFF
--- a/nodel-webui-js/src/templates.xsl
+++ b/nodel-webui-js/src/templates.xsl
@@ -16,7 +16,7 @@
   </xsl:template>
   <!-- row -->
   <!-- column -->
-  <xsl:template match="column[not(@sm|md|xs)]">
+  <xsl:template match="column[not(@lg|@md|@sm|@xs)]">
     <div>
       <xsl:choose>
         <xsl:when test="@event or @showevent">
@@ -71,7 +71,7 @@
       <xsl:apply-templates/>
     </div>
   </xsl:template>
-  <xsl:template match="column[@sm|@md|@xs]">
+  <xsl:template match="column[@lg|@md|@sm|@xs]">
     <div>
       <xsl:choose>
         <xsl:when test="@event or @showevent">
@@ -89,6 +89,11 @@
             <xsl:if test="@md">
               <xsl:text>col-md-</xsl:text>
               <xsl:value-of select="@md"/>
+              <xsl:text> </xsl:text>
+            </xsl:if>            
+            <xsl:if test="@lg">
+              <xsl:text>col-lg-</xsl:text>
+              <xsl:value-of select="@lg"/>
             </xsl:if>
             <xsl:text> sect</xsl:text>
             <xsl:if test="@push">
@@ -138,6 +143,11 @@
             <xsl:if test="@md">
               <xsl:text>col-md-</xsl:text>
               <xsl:value-of select="@md"/>
+              <xsl:text> </xsl:text>
+            </xsl:if>
+            <xsl:if test="@lg">
+              <xsl:text>col-lg-</xsl:text>
+              <xsl:value-of select="@lg"/>
             </xsl:if>
             <xsl:if test="@push">
               <xsl:text> col-sm-push-</xsl:text>


### PR DESCRIPTION
I noticed while setting up a Frontend that despite there being reference to a **large** (>1200px) grid option in `nodel-webui-js/src/light/variables.less` there was no inclusion in the `templates.xsl` sheet.

This pull request makes those changes, and allows for a fourth (xs, sm, md, **+lg**) grid option when building frontends.

`<column sm='12' md='6' lg='4'>`