### PR TITLE
build: Node.js to 20.12.0 for ARM64 support

### DIFF
--- a/nodel-webui-js/build.gradle
+++ b/nodel-webui-js/build.gradle
@@ -43,12 +43,14 @@ if (!branch.equals("stable"))
     version project.version + "-" + branch + "_r" + rev
 
 node {
-    version = '12.19.0'
+    version = '20.12.0'
     download = true
 
     workDir = file("${project.buildDir}/nodejs")
-    nodeModulesDir = file("${project.projectDir}")
+    nodeProjectDir = file("${project.projectDir}")
 }
+
+npmInstall.args = ['--legacy-peer-deps']
 
 task gruntRun(type: NpmTask, dependsOn: [npmInstall]) {
     args = ['run-script', 'run-grunt']


### PR DESCRIPTION
Update Node.js version to 20.12.0 to get access to ARM64 binaries for building on Apple Silicon. Also add `--legacy-peer deps` flag introduced in later node versions which removes the heavy dependency graph restrictions to allow building old dependencies without any further changes.

They're not available until version 16+ but only 18 and 20 are LTS versions.