### PR TITLE
feature: Re-introduce unit testing to framework

### DIFF
--- a/nodel-framework/build.gradle
+++ b/nodel-framework/build.gradle
@@ -14,10 +14,29 @@ jar {
     }
 }
 
+compileJava {
+    options.release = 8
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+    }
+}
+
 dependencies {
     implementation 'joda-time:joda-time:2.6'
     implementation 'org.slf4j:slf4j-api:1.7.10'
 
     // SSH features
     implementation group: 'com.jcraft', name: 'jsch', version: '0.1.55'
+
+    // Test dependencies
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.mockito:mockito-core:3.+'
+    testImplementation 'ch.qos.logback:logback-classic:1.4.14'
 }
+

--- a/nodel-framework/src/test/java/org/nodel/GitHubIssue.java
+++ b/nodel-framework/src/test/java/org/nodel/GitHubIssue.java
@@ -1,0 +1,12 @@
+package org.nodel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GitHubIssue {
+    String value(); // The URL or ID of the GitHub issue
+}

--- a/nodel-framework/src/test/java/org/nodel/SimpleNameTest.java
+++ b/nodel-framework/src/test/java/org/nodel/SimpleNameTest.java
@@ -1,0 +1,37 @@
+package org.nodel;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SimpleNameTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "node_name",
+            "Node Name",
+            "node-name",
+            "node.name",
+            "node name"
+    })
+    void testGetOriginalName(String originalName) {
+        SimpleName name = new SimpleName(originalName);
+        assertEquals(originalName, name.getOriginalName());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "node_name, nodename",
+            "Node Name, NodeName",
+            "node-name, nodename",
+            "node.name, nodename",
+            "node name, nodename"
+    })
+    public void testGetReducedName(String originalName, String expectedReducedName) {
+        SimpleName name = new SimpleName(originalName);
+        assertEquals(expectedReducedName, name.getReducedName());
+    }
+}

--- a/nodel-framework/src/test/java/org/nodel/toolkit/ManagedToolkitTest.java
+++ b/nodel-framework/src/test/java/org/nodel/toolkit/ManagedToolkitTest.java
@@ -1,0 +1,91 @@
+package org.nodel.toolkit;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.nodel.GitHubIssue;
+import org.nodel.SimpleName;
+import org.nodel.core.NodelServerAction;
+import org.nodel.core.NodelServerEvent;
+import org.nodel.core.NodelServers;
+import org.nodel.host.BaseDynamicNode;
+import org.nodel.host.Binding;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ManagedToolkitTest {
+
+    private ManagedToolkit managedToolkit;
+    private Binding metadata;
+    private ActionFunction actionFunction;
+
+    @FunctionalInterface
+    interface ActionFunction {
+        void handle(Object arg);
+    }
+
+    @BeforeEach
+    void setUp() {
+        BaseDynamicNode mockNode = mock(BaseDynamicNode.class);
+        when(mockNode.getName()).thenReturn(new SimpleName("MockNode"));
+        managedToolkit = new ManagedToolkit(mockNode);
+        metadata = new Binding();
+        actionFunction = arg -> {};
+    }
+
+    @Disabled("Awaiting fix for issue: #284")
+    @DisplayName("Original name of generated action")
+    @GitHubIssue("https://github.com/museumsvictoria/nodel/issues/284")
+    @ParameterizedTest
+    @CsvSource({
+            "Action With Spaces, Action With Spaces",
+            "Action-With-Hyphens, Action-With-Hyphens",
+    })
+    void testCreateActionWithDefaultName(String actionName, String expectedName) {
+        try (NodelServerAction action = managedToolkit.createAction(actionName, actionFunction::handle, metadata)) {
+            assertEquals(expectedName, action.getAction().getOriginalName());
+        }
+    }
+
+    @DisplayName("Reduced name of generated action")
+    @ParameterizedTest
+    @CsvSource({
+            "Action With Spaces, ActionWithSpaces",
+            "Action-With-Hyphens, ActionWithHyphens",
+    })
+    void testCreateActionWithReducedName(String actionName, String expectedName) {
+        try (NodelServerAction action = managedToolkit.createAction(actionName, actionFunction::handle, metadata)) {
+            assertEquals(expectedName, action.getAction().getReducedName());
+        }
+    }
+
+    @Disabled("Awaiting fix for issue: #284")
+    @DisplayName("Original name of generated event")
+    @GitHubIssue("https://github.com/museumsvictoria/nodel/issues/284")
+    @ParameterizedTest
+    @CsvSource({
+            "Event With Spaces, Event With Spaces",
+            "Event-With-Hyphens, Event-With-Hyphens",
+    })
+    void testCreateEventWithDefaultName(String eventName, String expectedName) {
+        try (NodelServerEvent event = managedToolkit.createEvent(eventName, metadata)) {
+            NodelServers.instance().registerEvent(event);
+            assertEquals(expectedName, event.getEvent().getOriginalName());
+        }
+    }
+
+    @DisplayName("Reduced name of generated event")
+    @ParameterizedTest
+    @CsvSource({
+            "Event With Spaces, EventWithSpaces",
+            "Event-With-Hyphens, EventWithHyphens",
+    })
+
+    void testCreateEventWithReducedName(String eventName, String expectedName) {
+        try (NodelServerEvent event = managedToolkit.createEvent(eventName, metadata)) {
+            NodelServers.instance().registerEvent(event);
+            assertEquals(expectedName, event.getEvent().getReducedName());
+        }
+    }
+}

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -13,6 +13,10 @@ application {
     mainClass = 'org.nodel.jyhost.Launch'
 }
 
+compileJava {
+    options.release = 8
+}
+
 jar {
     from "$buildDir/output"
     archiveBaseName = 'nodel-jyhost'

--- a/nodel-webui-js/build.gradle
+++ b/nodel-webui-js/build.gradle
@@ -17,6 +17,10 @@ plugins {
     id 'com.github.node-gradle.node' version '7.0.2'
 }
 
+compileJava {
+    options.release = 8
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
A little fumbling with git has caused me to hard reset a poor merge of https://github.com/museumsvictoria/nodel/pull/314 and re-introduce it here.

It was caused be quite a bit too much rebasing while working on more than one PR at a time.

---

A reminder, we're essentially just introducing a couple of dependencies and some example unit tests in this PR.