### PR TITLE
bug #331: HTTP client proxy value incorrectly parsed, added extra doco

### DIFF
--- a/nodel-jyhost/src/main/java/org/nodel/http/impl/ApacheNodelHttpClient.java
+++ b/nodel-jyhost/src/main/java/org/nodel/http/impl/ApacheNodelHttpClient.java
@@ -144,7 +144,7 @@ public class ApacheNodelHttpClient extends NodelHTTPClient {
         
         try {
             int lastIndexOfColon = proxyAddress.lastIndexOf(':');
-            proxyHost = proxyAddress.substring(0, lastIndexOfColon - 1);
+            proxyHost = proxyAddress.substring(0, lastIndexOfColon);
             proxyPort = Integer.parseInt(proxyAddress.substring(lastIndexOfColon + 1));
         } catch (Exception ignore) {
         }

--- a/nodel-jyhost/src/main/resources/org/nodel/jyhost/nodetoolkit.py
+++ b/nodel-jyhost/src/main/resources/org/nodel/jyhost/nodetoolkit.py
@@ -93,6 +93,12 @@ def get_url(url, method=None, query=None, username=None, password=None, headers=
     return nodetoolkit.getHttpClient().makeRequest(url, method, query, username, password, headers, contentType, post, long(connectTimeout*1000), long(readTimeout*1000))
   else:
     return nodetoolkit.getHttpClient().makeSimpleRequest(url, method, query, username, password, headers, contentType, post, long(connectTimeout*1000), long(readTimeout*1000))
+  
+# For HTTP proxy use, call this before any other HTTP client operations: 
+#     _toolkit.getHttpClient().setProxy("PROXY_HOST:PORT_PORT", USERNAME or None, PASSWORD or None)
+
+# To ignore HTTPS certificate verification:
+#     _toolkit.getHttpClient().setIgnoreSSL(True)
 
 # DEPRECATED (same as above)
 def getURL(url, method=None, query=None, username=None, password=None, headers=None, contentType=None, post=None, connectTimeout=10, readTimeout=15):


### PR DESCRIPTION
A very simple bug in the rarely used HTTP CLIENT PROXY code.

Some extra documentation related to the HTTP client was added too.