### PR TITLE
bug #325: Fix print output in @at_cleanup functions not appearing in node console

### DIFF
--- a/nodel-jyhost/src/main/java/org/nodel/jyhost/PyNode.java
+++ b/nodel-jyhost/src/main/java/org/nodel/jyhost/PyNode.java
@@ -892,17 +892,28 @@ public class PyNode extends BaseDynamicNode {
      */
     private void cleanupInterpreter() {
         String message;
-        
+
         if (_python != null) {
             message = "(closing this interpreter...)";
 
             _logger.info(message);
             _outReader.inject(message);
-            
+
             try {
+                // Ensure the PySystemState is set before executing cleanup functions
+                PySystemState systemState = _python.getSystemState();
+                if (systemState == null)
+                    throw new IllegalStateException("Python interpreter not ready.");
+
+                Py.setSystemState(systemState);
+
+                // Reassign the output streams
+                _python.setOut(_outReader);
+                _python.setErr(_errReader);
+
                 PyFunction processCleanupFunctions = (PyFunction) _globals.get(Py.java2py("processCleanupFunctions"));
                 long cleanupFnCount = processCleanupFunctions.__call__().asLong();
-                
+
                 if (cleanupFnCount > 0) {
                     message = "('@at_cleanup' function" + (cleanupFnCount == 1 ? "" : "s") + " completed.)";
                     _logger.info(message);
@@ -912,14 +923,14 @@ public class PyNode extends BaseDynamicNode {
                 // upstream exception handling should mean we never get here, but just in case
                 _logger.warn("Unexpected exception during cleaning up; should be safe to ignore", exc);
             }
-            
+
             _python.cleanup();
-            
+
             message = "(clean up complete)";
             _logger.info(message);
             _outReader.inject(message);
         }
-        
+
         if (_toolkit != null) {
             _toolkit.shutdown();
         }


### PR DESCRIPTION
As described in https://github.com/museumsvictoria/nodel/issues/325 `print` messages aren't redirected to the Nodel console during clean-up.

The issue appears to be that when the cleanup function(s) are triggered, the Python interpreter's system state isn't set correctly, and subsequently `sys.stdout` and `sys.stderr` redirects aren't established.

This PR does the most obvious thing and (1) resets the interpreter's state and (2) assigns the output streams to the node's console before running through the list of clean-up functions provided by a node.

![2024-10-07_8PrPbcLW](https://github.com/user-attachments/assets/7be98092-b26b-430c-b209-340ac2a58920)