### PR TITLE
Update README to clarify preferred JRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The platform-independent nature of Nodel also allows it to easily scale to suit 
 System requirements
 ============
 
-* Any operating system capable of hosting the Java 8 Runtime Environment – including OS X, Windows or Linux 
+* Any operating system capable of hosting the Java Runtime Environment (Java 8+) – including OS X, Windows or Linux 
 * A current web browser
 * Made for mobile
 
@@ -106,6 +106,7 @@ Building and releases
 Notes
 =====
 * thoroughly road tested with Java 8 (available from [AdoptOpenJDK](https://adoptopenjdk.net/))
+* also runs fine on Java 21 LTS despite console warnings
 * for service / daemon use, see [wiki pages](https://github.com/museumsvictoria/nodel/wiki)
 * check `bootstrap` files for startup config
 


### PR DESCRIPTION
Just wanted to codify a conversion with @justparking where we confirmed that Java 21 was a good candidate to settle on, as Java 8 is getting on.