### PR TITLE
feature: Add MAC for interface selection

### DIFF
--- a/nodel-framework/src/main/java/org/nodel/host/BootstrapConfig.java
+++ b/nodel-framework/src/main/java/org/nodel/host/BootstrapConfig.java
@@ -9,6 +9,7 @@ package org.nodel.host;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -307,19 +308,42 @@ public class BootstrapConfig {
 
         System.out.println();
         System.out.println("// Available network interfaces:");
-        System.out.println("// (use --interface ... [--interface ...] to enable opt-in interface binding)");
+        System.out.println("// (use --interface ... [--interface ...] to enable binding by interface name or MAC)");
         System.out.println("{ \"networkInterfaces\": [");
 
         String[] names = networkInterfaceNames();
         for (int i = 0; i < names.length; i++) {
+            String name = names[i];
             try {
-                System.out.format("    \"%s\"%s  // %s%n", names[i], i != names.length - 1 ? "," : "", NetworkInterface.getByName(names[i]).getDisplayName());
-
+                NetworkInterface ni = NetworkInterface.getByName(name);
+                String display = ni.getDisplayName();
+                String mac;
+                try {
+                    byte[] hw = ni.getHardwareAddress();
+                    if (hw != null && hw.length > 0) {
+                        StringBuilder sb = new StringBuilder();
+                        for (int j = 0; j < hw.length; j++) {
+                            sb.append(String.format("%02X", hw[j]));
+                            if (j < hw.length - 1) sb.append(":");
+                        }
+                        mac = sb.toString();
+                    } else {
+                        mac = "n/a";
+                    }
+                } catch (SocketException se) {
+                    mac = "n/a";
+                }
+                System.out.format(
+                    "    \"%s\"%s  // %s, MAC=%s%n",
+                    name,
+                    (i != names.length - 1 ? "," : ""),
+                    display,
+                    mac
+                );
             } catch (Exception exc) {
                 // ignore
             }
-
-        } // (for)
+        }
         System.out.println("}");
 
         System.out.println();

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -15,9 +15,6 @@ def branch = gitBranch
 if (branch.equals("master"))
     branch = "dev"
 
-// sanitize branch: replace slashes and other non-filename characters with hyphens
-branch = branch.replaceAll(/[^A-Za-z0-9._-]+/, '-')
-
 def rev = gitRev
 // strip out non-alphanumeric (e.g. the '+' in '1234+')
 rev = rev.replaceAll(/[^a-zA-Z0-9]/, '')

--- a/nodel-jyhost/build.gradle
+++ b/nodel-jyhost/build.gradle
@@ -15,6 +15,9 @@ def branch = gitBranch
 if (branch.equals("master"))
     branch = "dev"
 
+// sanitize branch: replace slashes and other non-filename characters with hyphens
+branch = branch.replaceAll(/[^A-Za-z0-9._-]+/, '-')
+
 def rev = gitRev
 // strip out non-alphanumeric (e.g. the '+' in '1234+')
 rev = rev.replaceAll(/[^a-zA-Z0-9]/, '')

--- a/nodel-jyhost/src/main/java/org/nodel/jyhost/Launch.java
+++ b/nodel-jyhost/src/main/java/org/nodel/jyhost/Launch.java
@@ -12,8 +12,13 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.net.BindException;
+import java.net.NetworkInterface;
 import java.net.ServerSocket;
+import java.net.SocketException;
 import java.nio.channels.FileLock;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.nodel.StartupException;
@@ -235,9 +240,13 @@ public class Launch {
         createHostInstanceLockOrFail();
 	    
         // opt-in interfaces
-        String[] interfaces = _bootstrapConfig.getNetworkInterfaces();
-        if (interfaces != null && interfaces.length > 0) {
-            Nodel.setInterfacesToUse(_bootstrapConfig.getNetworkInterfaces());
+        String[] specs = _bootstrapConfig.getNetworkInterfaces();
+        if (specs != null && specs.length > 0) {
+            List<String> resolved = new ArrayList<>();
+            for (String spec : specs) {
+                resolved.add(resolveNetworkInterface(spec));
+            }
+            Nodel.setInterfacesToUse(resolved.toArray(new String[0]));
         }
         
         // check if advertisements should be disabled
@@ -621,4 +630,37 @@ public class Launch {
         }
     }
     
+    /** Heuristic to detect MAC address specs. */
+    private boolean looksLikeMac(String spec) {
+        return spec.matches("(?i)^(?:[0-9A-F]{2}(?:[:-])){5}[0-9A-F]{2}$")
+            || spec.matches("(?i)^[0-9A-F]{12}$");
+    }
+
+    /** Resolve spec to interface name: MAC→name; else literal spec. */
+    private String resolveNetworkInterface(String spec) {
+        if (looksLikeMac(spec)) {
+            String normSpec = spec.replaceAll("[:-]", "").toUpperCase();
+            try {
+                Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
+                while (ifaces.hasMoreElements()) {
+                    NetworkInterface ni = ifaces.nextElement();
+                    byte[] hw = ni.getHardwareAddress();
+                    if (hw != null) {
+                        StringBuilder sb = new StringBuilder();
+                        for (byte b : hw) {
+                            sb.append(String.format("%02X", b));
+                        }
+                        if (sb.toString().equals(normSpec)) {
+                            _logger.info("Resolved MAC spec " + spec + " → interface " + ni.getName());
+                            return ni.getName();
+                        }
+                    }
+                }
+            } catch (SocketException e) {
+                _logger.warn("Error enumerating interfaces for MAC match", e);
+            }
+            _logger.warn("Could not resolve MAC spec '" + spec + "'; using literal spec");
+        }
+        return spec;
+    }
 }


### PR DESCRIPTION
- networkInterfaces now accepts MAC addresses
- MACs are resolved to the correct interface
- Help output lists interface names and MACs for easy config.
- Backward compatible; addresses #351.
- <del>Unrelated fix to flatten branch names in build output</del>

Here are some examples for both `bootstrap,json`
```
{
  "networkInterfaces": [
    "eth0",                    // legacy: by name
    "aa:bb:cc:dd:ee:ff",       // MAC address with colons
    "AA-BB-CC-DD-EE-FF",       // MAC address with dashes
    "AABBCCDDEEFF"             // MAC address, no separators
  ]
}
```

and, CLI
```
java -jar nodel.jar --interface eth0
java -jar nodel.jar --interface aa:bb:cc:dd:ee:ff
```
