### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,66 @@
+# =============================================================================
+# Docker Build Context Exclusions
+# =============================================================================
+# Exclude files that aren't needed in the build context to speed up builds
+# and reduce the amount of data sent to the Docker daemon.
+# =============================================================================
+
+# Git (keep .git for version detection during build)
+.gitignore
+.gitattributes
+
+# IDE
+.idea/
+*.iml
+.vscode/
+*.swp
+*.swo
+*~
+
+# Build outputs (we rebuild inside Docker)
+build/
+*/build/
+out/
+*.class
+
+# Gradle caches
+.gradle/
+*/.gradle/
+
+# Node modules (rebuilt inside Docker)
+nodel-webui-js/node_modules/
+
+# Local runtime data
+nodes/
+recipes/
+custom/
+cache/
+logs/
+*.lock
+.nodel/
+
+# Generated files
+_*.json
+_*.txt
+.version
+.lastHTTPPort
+
+# Documentation (not needed for build)
+*.md
+!README.md
+LICENSE*
+
+# CI/CD
+.travis.yml
+.github/
+
+# Docker files (avoid recursive context)
+docker-compose*.yml
+
+# Test data
+test-nodes/
+test-data/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Auto-detect text files and normalise line endings
+* text=auto
+
+# Shell scripts must use LF (Unix) line endings for Docker/Linux compatibility
+*.sh text eol=lf
+gradlew text eol=lf
+entrypoint.sh text eol=lf
+
+# Windows batch files use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,154 @@
+# Publishes Docker images to GitHub Container Registry (GHCR)
+#
+# Triggers:
+#   - Version tags (v*): Builds and pushes automatically
+#   - Manual dispatch: Build any branch, optional push
+#
+# Manual builds via CLI (useful for testing branches):
+#   gh workflow run docker-publish.yml --ref <branch> --repo <owner>/nodel
+#   gh workflow run docker-publish.yml --ref <branch> --repo <owner>/nodel -f push_image=true
+#
+# Image naming: ghcr.io/<owner>/nodel:<tag>
+
+name: Docker | Build and Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to registry'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version metadata
+        id: version
+        run: |
+          REV_COUNT=$(git rev-list --count HEAD)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BASE_VERSION=$(grep "baseVersion = " build.gradle | sed "s/.*baseVersion = '\([^']*\)'.*/\1/")
+
+          # Validate all extracted values
+          if [[ -z "$BASE_VERSION" ]]; then
+            echo "::error::Failed to extract baseVersion from build.gradle"
+            exit 1
+          fi
+          # Validate version format for Docker tag compatibility
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "::error::Invalid version format: '$BASE_VERSION' (expected semver-like pattern)"
+            exit 1
+          fi
+          if [[ -z "$REV_COUNT" || ! "$REV_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Failed to get valid commit count (got: '$REV_COUNT')"
+            exit 1
+          fi
+          if [[ -z "$SHORT_SHA" ]]; then
+            echo "::error::Failed to get short SHA"
+            exit 1
+          fi
+
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"
+          else
+            BRANCH="${{ github.ref_name }}"
+            BRANCH="${BRANCH//\//-}"
+            VERSION="${BASE_VERSION}-${BRANCH}.r${REV_COUNT}"
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "revision=${REV_COUNT}" >> $GITHUB_OUTPUT
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "base_version=${BASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref, '-') }}
+            type=ref,event=branch
+            type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=Nodel
+            org.opencontainers.image.description=Digital media control system for museums, galleries, and corporate environments
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.vendor=Museums Victoria
+            org.opencontainers.image.licenses=MPL-2.0
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.build_date }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref_type == 'tag' || inputs.push_image }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_DATE=${{ steps.version.outputs.build_date }}
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate build summary
+        run: |
+          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ github.ref_type }}" == "tag" || "${{ inputs.push_image }}" == "true" ]]; then
+            echo "✅ **Status:** Image pushed to registry" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏸️ **Status:** Image built but NOT pushed" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.ref_type == 'tag' || inputs.push_image }}
+          push: ${{ github.ref_type == 'tag' || inputs.push_image == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@
 .lastHTTPPort
 _instance.lock
 _lastError.txt
+/nodes/
+/custom/
+/logs/
+/cache/
+/docker-compose.override.yml
+/recipes/nodel-official-recipes/
 /nodel-webui-js/.classpath
 /nodel-webui-js/.project
 /nodel-webui-js/.settings

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,127 @@
+<div align="center">
+
+  <img src="http://nodel.io/media/1066/logo-nodel.png" alt="Nodel logo" height="110">
+
+  <h3>Nodel, on Docker.</h3>
+
+  <p>
+    <a href="https://github.com/museumsvictoria/nodel/pkgs/container/nodel">
+      <img src="https://img.shields.io/badge/registry-ghcr.io-blue" alt="Container Registry">
+    </a>
+  </p>
+
+</div>
+
+##### Run Nodel anywhere Docker runs.
+
+The official container image packages everything needed to get started in seconds.
+
+###### Why Docker?
+
+* No Java installation required on the host
+* Consistent environment across all deployments
+* Easy updates with a single pull command
+* Isolated from host system dependencies
+
+-------------
+
+Quick Start
+===========
+
+The fastest way to get Nodel running is with the install script:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+```
+
+This creates a persistent container named `nodel` on port 8085. Once running, open http://localhost:8085 in your browser.
+
+> **Tip:** Customise with `PORT`, `NAME`, or `IMAGE` env vars before the command.
+
+Running Nodel
+=============
+
+Pull the image:
+
+```bash
+docker pull ghcr.io/museumsvictoria/nodel:latest
+```
+
+Interactive (Ctrl+C to stop):
+
+```bash
+docker run --rm -it -p 8085:8085 ghcr.io/museumsvictoria/nodel
+```
+
+Detached with auto-restart:
+
+```bash
+docker run -d --name nodel -p 8085:8085 --restart unless-stopped \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Pass Nodel arguments after the image name:
+
+```bash
+docker run --rm -it -p 8086:8086 ghcr.io/museumsvictoria/nodel -p 8086
+```
+
+Development
+===========
+
+Build and run using Docker Compose:
+
+```bash
+docker compose up --build -d
+```
+
+> **Tip:** Use a `docker-compose.override.yml` to swap in a local image or tweak settings without modifying the base file.
+
+Data Persistence
+================
+
+Node configurations are stored inside the container by default. Named containers retain data across restarts, but it's lost if the container is removed (`docker rm`). Mount host directories as volumes to keep data independent of the container lifecycle.
+
+Mount your nodes folder:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
+  -v ./nodes:/app/nodes \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Or mount multiple directories:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
+  -v ./nodes:/app/nodes \
+  -v ./recipes:/app/recipes \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Configuration
+=============
+
+### JVM options
+
+Tune Java memory settings with the `JAVA_OPTS` environment variable:
+
+```bash
+docker run -d --name nodel -p 8085:8085 \
+  -e JAVA_OPTS="-XX:MaxRAMPercentage=50.0 -Xms256m" \
+  ghcr.io/museumsvictoria/nodel
+```
+
+Default JVM options: `-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0`
+
+### Health check
+
+The image includes a built-in health check that polls `/REST/` every 30 seconds. It automatically detects the HTTP port from `.lastHTTPPort` if present.
+
+Notes
+=====
+
+* Trigger an image build manually: `gh workflow run docker-publish.yml --ref <branch> -f push_image=true`
+* Images are available for both `amd64` and `arm64` architectures
+* For service/daemon setup on the host, see the [wiki pages](https://github.com/museumsvictoria/nodel/wiki)
+* Drop [recipes](https://github.com/museumsvictoria/nodel-recipes) into the nodes folder to get started

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1
+# Build stage
+FROM eclipse-temurin:21-jdk AS builder
+
+# Git enables build metadata (branch, revision) from the checked-out repo.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Prefer cached dependency downloads by copying build descriptors first.
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle/ ./gradle/
+COPY nodel-framework/build.gradle nodel-framework/build.gradle
+COPY nodel-jyhost/build.gradle nodel-jyhost/build.gradle
+COPY nodel-webui-js/build.gradle nodel-webui-js/build.gradle
+COPY nodel-webui-js/package.json nodel-webui-js/package.json
+COPY nodel-webui-js/package-lock.json nodel-webui-js/package-lock.json
+COPY nodel-webui-js/Gruntfile.js nodel-webui-js/Gruntfile.js
+
+RUN --mount=type=cache,target=/root/.gradle \
+    chmod +x gradlew \
+    && ./gradlew :nodel-jyhost:dependencies --no-daemon
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :nodel-jyhost:unversioned --no-daemon \
+    && test -s nodel-jyhost/build/distributions/standalone/nodelhost.jar \
+    && cp nodel-jyhost/build/distributions/standalone/nodelhost.jar /build/nodelhost.jar
+
+# Runtime stage
+FROM eclipse-temurin:21-jre-alpine
+
+# Static labels
+LABEL org.opencontainers.image.title="Nodel" \
+      org.opencontainers.image.description="Digital media control system for museums, galleries, and corporate environments" \
+      org.opencontainers.image.url="https://github.com/museumsvictoria/nodel" \
+      org.opencontainers.image.source="https://github.com/museumsvictoria/nodel" \
+      org.opencontainers.image.vendor="Museums Victoria" \
+      org.opencontainers.image.licenses="MPL-2.0"
+
+# Dynamic labels (optional build args)
+ARG VERSION
+ARG BUILD_DATE
+ARG GIT_COMMIT
+
+LABEL org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${GIT_COMMIT}"
+
+# Install tini for proper signal handling.
+RUN apk add --no-cache tini
+
+WORKDIR /app
+COPY --from=builder /build/nodelhost.jar .
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+
+# JVM tuning: UseContainerSupport (default since Java 10) enables container-aware memory limits;
+# RAM percentages cap heap relative to container memory to reduce OOM risk
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+
+# Default port (configurable via bootstrap.json NodelHostPort setting)
+EXPOSE 8085
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD wget -q --spider http://localhost:$(cat /app/.lastHTTPPort 2>/dev/null || echo 8085)/REST/
+
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ COPY nodel-webui-js/package-lock.json nodel-webui-js/package-lock.json
 COPY nodel-webui-js/Gruntfile.js nodel-webui-js/Gruntfile.js
 
 RUN --mount=type=cache,target=/root/.gradle \
-    chmod +x gradlew \
+    # Normalize line endings for Windows clones so /bin/sh can run gradlew.
+    sed -i 's/\r$//' gradlew \
+    && chmod +x gradlew \
     && ./gradlew :nodel-jyhost:dependencies --no-daemon
 
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# Development compose file - for building and testing locally
+# For production deployments, use install.sh instead
+services:
+  nodel:
+    build: .
+    image: nodel:local
+    ports:
+      - "8085:8085"
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ ! -f /app/nodelhost.jar ]; then
+  echo "ERROR: nodelhost.jar not found" >&2
+  exit 1
+fi
+
+# tail -f /dev/null keeps stdin open (Nodel reads stdin; EOF triggers graceful exit)
+exec tail -f /dev/null | java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,15 @@ if [ ! -f /app/nodelhost.jar ]; then
   exit 1
 fi
 
-# tail -f /dev/null keeps stdin open (Nodel reads stdin; EOF triggers graceful exit)
-exec tail -f /dev/null | java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@"
+# Keep stdin open without masking signals (Nodel reads stdin; EOF triggers graceful exit).
+stdin_fifo="/tmp/nodel-stdin"
+if [ -e "$stdin_fifo" ] && [ ! -p "$stdin_fifo" ]; then
+  rm -f "$stdin_fifo"
+fi
+if [ ! -p "$stdin_fifo" ]; then
+  mkfifo "$stdin_fifo"
+fi
+
+tail -f /dev/null > "$stdin_fifo" &
+
+exec java ${JAVA_OPTS:-} -jar /app/nodelhost.jar "$@" < "$stdin_fifo"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# Nodel Docker Installer
+#
+# Usage:
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+#
+# With options:
+#   PORT=8086 NAME=nodel2 IMAGE=ghcr.io/scroix/nodel:latest \
+#     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/museumsvictoria/nodel/master/install.sh)"
+#
+set -e
+
+# Defaults (override with environment variables)
+PORT=${PORT:-8085}
+NAME=${NAME:-"nodel"}
+IMAGE=${IMAGE:-"ghcr.io/museumsvictoria/nodel:latest"}
+
+# Colours (if terminal supports them)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  NC='\033[0m' # No Colour
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  BLUE=''
+  NC=''
+fi
+
+log() {
+  echo -e "${BLUE}[nodel]${NC} $1"
+}
+
+error() {
+  echo -e "${RED}[error]${NC} $1" >&2
+}
+
+success() {
+  echo -e "${GREEN}[success]${NC} $1"
+}
+
+warn() {
+  echo -e "${YELLOW}[warn]${NC} $1"
+}
+
+# Check Docker is installed
+if ! command -v docker &> /dev/null; then
+  error "Docker is not installed"
+  echo ""
+  echo "Please install Docker first:"
+  echo "  https://docs.docker.com/get-docker/"
+  exit 1
+fi
+
+# Check Docker daemon is running
+if ! docker info &> /dev/null; then
+  error "Docker daemon is not running"
+  echo ""
+  echo "Please start Docker and try again"
+  exit 1
+fi
+
+# Check if container already exists
+if docker container inspect "$NAME" &> /dev/null; then
+  warn "Container '$NAME' already exists"
+  echo ""
+  echo "To reinstall, first remove the existing container:"
+  echo "  docker rm -f $NAME"
+  exit 1
+fi
+
+# Check if port is in use by another container
+if docker ps --format '{{.Ports}}' | grep -q ":$PORT->"; then
+  warn "Port $PORT appears to be in use by another container"
+  exit 1
+fi
+
+log "Pulling Nodel image..."
+docker pull "$IMAGE"
+
+log "Starting Nodel..."
+docker run -d \
+  --name "$NAME" \
+  --restart unless-stopped \
+  -p "$PORT:$PORT" \
+  "$IMAGE" -p "$PORT" > /dev/null
+
+echo ""
+success "Nodel is running!"
+echo ""
+echo "  Web UI:    http://localhost:$PORT"
+echo ""
+echo "Commands:"
+echo "  docker logs $NAME       # View logs"
+echo "  docker stop $NAME       # Stop Nodel"
+echo "  docker start $NAME      # Start Nodel"
+echo "  docker rm -f $NAME      # Remove container"

--- a/nodel-framework/src/main/java/org/nodel/discovery/TopologyWatcher.java
+++ b/nodel-framework/src/main/java/org/nodel/discovery/TopologyWatcher.java
@@ -373,11 +373,26 @@ public class TopologyWatcher {
                     // skip this interface
                 }
             }
-            
-            hostname = InetAddress.getLocalHost().getHostName();
-            
+
         } catch (Exception exc) {
-            _logger.warn("TopologyWatcher: Was not able to enumerate network interfaces or get hostname", exc);
+            _logger.warn("TopologyWatcher: Was not able to enumerate network interfaces", exc);
+        }
+
+        // Separate hostname lookup - can fail independently (e.g., in Docker containers)
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (Exception exc) {
+            // Fallback: try system property or environment variable
+            hostname = System.getProperty("nodel.hostname");
+            if (hostname == null || hostname.isEmpty()) {
+                hostname = System.getenv("HOSTNAME");
+            }
+            if (hostname == null || hostname.isEmpty()) {
+                hostname = "UNKNOWN";
+                _logger.debug("TopologyWatcher: Could not resolve hostname, using UNKNOWN", exc);
+            } else {
+                _logger.debug("TopologyWatcher: Using hostname from environment: {}", hostname);
+            }
         }
 
         if (optInList.length > 0 && !foundAnyMatch) {

--- a/nodel-webui-js/build.gradle
+++ b/nodel-webui-js/build.gradle
@@ -48,6 +48,7 @@ npmInstall.args = ['--legacy-peer-deps']
 
 class FileChecker {
     def nodeModulesDir
+    def gruntOutputDir
     def srcDir
     def packageJson
     def packageLockJson
@@ -55,6 +56,7 @@ class FileChecker {
 
     FileChecker(Project project) {
         nodeModulesDir = project.file("${project.projectDir}/node_modules")
+        gruntOutputDir = project.file("${project.buildDir}/grunt")
         srcDir = project.file('src')
         packageJson = project.file('package.json')
         packageLockJson = project.file('package-lock.json')
@@ -62,18 +64,23 @@ class FileChecker {
     }
 
     def checkFilesChanged() {
+        // Always rebuild if grunt output doesn't exist or is empty
+        if (!gruntOutputDir.exists() || gruntOutputDir.list()?.length == 0) {
+            return true
+        }
+
+        // Need npm install + grunt if node_modules is missing
         if (!nodeModulesDir.exists()) {
             return true
-        } else {
-            def srcDirModified = srcDir.exists() && srcDir.lastModified() > nodeModulesDir.lastModified()
-            def packageJsonModified = packageJson.exists() && packageJson.lastModified() > nodeModulesDir.lastModified()
-            def packageLockJsonModified = packageLockJson.exists() && packageLockJson.lastModified() > nodeModulesDir.lastModified()
-            def gruntFileModified = gruntFile.exists() && gruntFile.lastModified() > nodeModulesDir.lastModified()
-
-            def filesChanged = srcDirModified || packageJsonModified || packageLockJsonModified || gruntFileModified
-
-            return filesChanged
         }
+
+        // Check if sources are newer than grunt output
+        def srcDirModified = srcDir.exists() && srcDir.lastModified() > gruntOutputDir.lastModified()
+        def packageJsonModified = packageJson.exists() && packageJson.lastModified() > gruntOutputDir.lastModified()
+        def packageLockJsonModified = packageLockJson.exists() && packageLockJson.lastModified() > gruntOutputDir.lastModified()
+        def gruntFileModified = gruntFile.exists() && gruntFile.lastModified() > gruntOutputDir.lastModified()
+
+        return srcDirModified || packageJsonModified || packageLockJsonModified || gruntFileModified
     }
 }
 


### PR DESCRIPTION
### Summary

Adds Docker support for running Nodel in containers.

A couple of highlights include (1) automated image publishing to GHCR and (2) the introduction of a `install.sh` one-liner for quick setup.

### Try it out... on a Unix system

  ```bash
IMAGE=ghcr.io/scroix/nodel:feature-docker-support /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/scroix/nodel/refs/heads/feature/docker-support/install.sh)"
```

> The final implementation would be a lot cleaner, but this is using a bunch of overrides until the official images exist.

![demo](https://github.com/user-attachments/assets/a2d1f8ce-46e2-4572-bcd9-c7fee67f902c)

#### Why Docker?

  - No Java installation required on the host
  - Consistent environment across deployments
  - Easy updates with docker pull

 #### Implementation notes

  - Uses tini for signal handling
  - Stdin kept open via tail -f /dev/null | (Nodel exits gracefully on EOF)
  - HEALTHCHECK polls /REST/ endpoint
  - Images auto-publish on version tags; manual dispatch available for testing