### PR TITLE
ci: add automatic tip (nightly) prerelease workflow

### DIFF
--- a/.github/workflows/tip-release.yml
+++ b/.github/workflows/tip-release.yml
@@ -1,0 +1,173 @@
+name: Tip Release
+
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: tip-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: >-
+      (github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.head_branch == 'dev')
+      || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.meta.outputs.sha }}
+      sha_short: ${{ steps.meta.outputs.sha_short }}
+      jar_name: ${{ steps.jar.outputs.name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Ensure branch name for versioning
+        run: git checkout -B dev ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve commit metadata
+        id: meta
+        run: |
+          SHA=${{ github.event.workflow_run.head_sha || github.sha }}
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+          cache: gradle
+
+      - name: Build jar (skip tests)
+        run: ./gradlew :nodel-jyhost:build -x test
+
+      - name: Locate jar
+        id: jar
+        run: |
+          JAR=$(ls nodel-jyhost/build/distributions/standalone/nodelhost-*.jar | head -n 1)
+          echo "name=$(basename "$JAR")" >> "$GITHUB_OUTPUT"
+          echo "path=$JAR" >> "$GITHUB_OUTPUT"
+
+      - name: Upload jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodelhost-jar
+          path: ${{ steps.jar.outputs.path }}
+          retention-days: 1
+
+  release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download jar
+        uses: actions/download-artifact@v4
+        with:
+          name: nodelhost-jar
+
+      - name: Generate release notes
+        run: |
+          cat > release_notes.md <<EOF
+          This tip release is automatically built on every push to \`dev\` that passes tests.
+
+          > [!WARNING]
+          > **This is a development build, not a stable release.**
+          > You can find stable releases on the [releases page]($RELEASES_URL).
+
+          ## Usage
+
+          - Requires **[Java 11](https://adoptium.net/temurin/releases/)** or later.
+          - \`java -jar $JAR_NAME\`
+          - Then open http://localhost:8085
+          EOF
+        env:
+          JAR_NAME: ${{ needs.build.outputs.jar_name }}
+          RELEASES_URL: https://github.com/${{ github.repository }}/releases
+
+      - name: Delete old release assets
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: "tip",
+            }).catch(() => ({ data: null }));
+            if (!release) return;
+            for (const asset of release.assets) {
+              await github.rest.repos.deleteReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                asset_id: asset.id,
+              });
+            }
+
+      - name: Upload release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: tip
+          name: Nodel Tip ("Nightly")
+          prerelease: true
+          body_path: release_notes.md
+          files: ${{ needs.build.outputs.jar_name }}
+          make_latest: false
+
+  tag:
+    needs: [release, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Move tip tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = '${{ needs.build.outputs.sha }}';
+            const tagName = 'tip';
+            const ref = `tags/${tagName}`;
+
+            // Create annotated tag object (GitHub signs this)
+            const { data: tagObject } = await github.rest.git.createTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: tagName,
+              message: `tip: ${{ needs.build.outputs.sha_short }}`,
+              object: sha,
+              type: 'commit',
+            });
+
+            // Update or create the ref to point to the tag object
+            try {
+              await github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref,
+                sha: tagObject.sha,
+                force: true,
+              });
+            } catch (e) {
+              if (e.status === 422) {
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `refs/${ref}`,
+                  sha: tagObject.sha,
+                });
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/tip-release.yml
+++ b/.github/workflows/tip-release.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Build and Test"]
     types: [completed]
+    branches: [dev]
   workflow_dispatch:
 
 concurrency:
@@ -15,9 +16,13 @@ jobs:
     if: >-
       (github.event_name == 'workflow_run'
         && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.head_branch == 'dev')
-      || github.event_name == 'workflow_dispatch'
+        && github.event.workflow_run.event == 'push'
+        && github.event.workflow_run.head_branch == 'dev'
+        && github.event.workflow_run.head_repository.full_name == github.repository)
+      || (github.event_name == 'workflow_dispatch'
+        && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:
@@ -27,7 +32,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
@@ -43,11 +49,15 @@ jobs:
           echo "sha_short=${SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Java 11
-        uses: actions/setup-java@v4
+        # actions/setup-java v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: "11"
-          cache: gradle
+
+      - name: Setup Gradle
+        # gradle/actions/setup-gradle v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
 
       - name: Build jar (skip tests)
         run: ./gradlew :nodel-jyhost:build -x test
@@ -60,7 +70,8 @@ jobs:
           echo "path=$JAR" >> "$GITHUB_OUTPUT"
 
       - name: Upload jar
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: nodelhost-jar
           path: ${{ steps.jar.outputs.path }}
@@ -69,45 +80,69 @@ jobs:
   release:
     needs: [build]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 
     steps:
       - name: Download jar
-        uses: actions/download-artifact@v4
+        # actions/download-artifact v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: nodelhost-jar
 
       - name: Generate release notes
         run: |
-          cat > release_notes.md <<EOF
-          This tip release is automatically built on every push to \`dev\` that passes tests.
+          cat > release_notes.md <<'EOF'
+          This tip release is automatically built on every push to `dev` that passes tests.
 
           > [!WARNING]
           > **This is a development build, not a stable release.**
-          > You can find stable releases on the [releases page]($RELEASES_URL).
+          > You can find stable releases on the [releases page](__RELEASES_URL__).
 
           ## Usage
 
           - Requires **[Java 11](https://adoptium.net/temurin/releases/)** or later.
-          - \`java -jar $JAR_NAME\`
+          - `java -jar __JAR_NAME__`
           - Then open http://localhost:8085
           EOF
+          sed -i \
+            -e "s|__JAR_NAME__|$JAR_NAME|g" \
+            -e "s|__RELEASES_URL__|$RELEASES_URL|g" \
+            release_notes.md
         env:
           JAR_NAME: ${{ needs.build.outputs.jar_name }}
           RELEASES_URL: https://github.com/${{ github.repository }}/releases
 
+      - name: Upload release
+        # softprops/action-gh-release v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        with:
+          tag_name: tip
+          target_commitish: ${{ needs.build.outputs.sha }}
+          name: Nodel Tip ("Nightly")
+          prerelease: true
+          body_path: release_notes.md
+          files: ${{ needs.build.outputs.jar_name }}
+          fail_on_unmatched_files: true
+          overwrite_files: true
+          make_latest: false
+
       - name: Delete old release assets
-        uses: actions/github-script@v7
+        # actions/github-script v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          CURRENT_ASSET_NAME: ${{ needs.build.outputs.jar_name }}
         with:
           script: |
+            const currentAssetName = process.env.CURRENT_ASSET_NAME;
             const { data: release } = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag: "tip",
-            }).catch(() => ({ data: null }));
-            if (!release) return;
+              tag: 'tip',
+            });
             for (const asset of release.assets) {
+              if (asset.name === currentAssetName) continue;
               await github.rest.repos.deleteReleaseAsset({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -115,32 +150,25 @@ jobs:
               });
             }
 
-      - name: Upload release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: tip
-          name: Nodel Tip ("Nightly")
-          prerelease: true
-          body_path: release_notes.md
-          files: ${{ needs.build.outputs.jar_name }}
-          make_latest: false
-
   tag:
     needs: [release, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
 
     steps:
       - name: Move tip tag
-        uses: actions/github-script@v7
+        # actions/github-script v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const sha = '${{ needs.build.outputs.sha }}';
             const tagName = 'tip';
             const ref = `tags/${tagName}`;
 
-            // Create annotated tag object (GitHub signs this)
+            // Move the public tip tag only after the release upload has succeeded.
+            // API-created annotated tags may be signed by GitHub.
             const { data: tagObject } = await github.rest.git.createTag({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
<img width="1486" height="1298" alt="2026-02-06_SAZJ7cVU@2x" src="https://github.com/user-attachments/assets/52b36606-10d2-4526-9558-74302e3f40be" />

Adds an always-current "tip" prerelease that rebuilds on every green push to `dev` — so there's always a downloadable jar for anyone who wants to test the latest without building from source.

The workflow chains three jobs (build → release → tag) so the release only publishes after a successful build, and the tag only moves after a successful release. Old assets are cleaned up before uploading, so the release page stays tidy.

Also supports `workflow_dispatch` for manual re-runs.

Inspired by [Ghostty's tip release](https://github.com/ghostty-org/ghostty/releases/tag/tip).