### PR TITLE
chore(ci): upgrade release actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout v4
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
@@ -88,15 +88,15 @@ jobs:
           git checkout -B "$BRANCH" "$SHA"
 
       - name: Setup Java 11
-        # actions/setup-java v4
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        # actions/setup-java v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
         with:
           distribution: temurin
           java-version: "11"
 
       - name: Setup Gradle
-        # gradle/actions/setup-gradle v4
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
+        # gradle/actions/setup-gradle v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
 
       - name: Run unit tests
         run: ./gradlew :nodel-framework:test
@@ -112,8 +112,8 @@ jobs:
           echo "path=$JAR" >> "$GITHUB_OUTPUT"
 
       - name: Upload jar
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: nodelhost-jar
           path: ${{ steps.jar.outputs.path }}
@@ -128,8 +128,8 @@ jobs:
 
     steps:
       - name: Download jar
-        # actions/download-artifact v4
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: nodelhost-jar
 
@@ -165,8 +165,8 @@ jobs:
             release_notes.md
 
       - name: Upload release
-        # softprops/action-gh-release v2
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        # softprops/action-gh-release v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: ${{ needs.build.outputs.tag }}
           target_commitish: ${{ needs.build.outputs.sha }}

--- a/.github/workflows/tip-release.yml
+++ b/.github/workflows/tip-release.yml
@@ -32,8 +32,8 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout v4
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
@@ -49,15 +49,15 @@ jobs:
           echo "sha_short=${SHA:0:7}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Java 11
-        # actions/setup-java v4
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        # actions/setup-java v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
         with:
           distribution: temurin
           java-version: "11"
 
       - name: Setup Gradle
-        # gradle/actions/setup-gradle v4
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
+        # gradle/actions/setup-gradle v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
 
       - name: Build jar (skip tests)
         run: ./gradlew :nodel-jyhost:build -x test
@@ -70,8 +70,8 @@ jobs:
           echo "path=$JAR" >> "$GITHUB_OUTPUT"
 
       - name: Upload jar
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: nodelhost-jar
           path: ${{ steps.jar.outputs.path }}
@@ -86,8 +86,8 @@ jobs:
 
     steps:
       - name: Download jar
-        # actions/download-artifact v4
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # actions/download-artifact v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: nodelhost-jar
 
@@ -115,8 +115,8 @@ jobs:
           RELEASES_URL: https://github.com/${{ github.repository }}/releases
 
       - name: Upload release
-        # softprops/action-gh-release v2
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        # softprops/action-gh-release v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: tip
           target_commitish: ${{ needs.build.outputs.sha }}
@@ -129,8 +129,8 @@ jobs:
           make_latest: false
 
       - name: Delete old release assets
-        # actions/github-script v7
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        # actions/github-script v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           CURRENT_ASSET_NAME: ${{ needs.build.outputs.jar_name }}
         with:
@@ -159,8 +159,8 @@ jobs:
 
     steps:
       - name: Move tip tag
-        # actions/github-script v7
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        # actions/github-script v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const sha = '${{ needs.build.outputs.sha }}';


### PR DESCRIPTION
Moves the Release and Tip Release workflows off deprecated Node 20 action revisions while keeping their shared SHA pins aligned. Gradle Actions stays on the Node 24-backed v5.0.2 line to avoid introducing v6’s separate enhanced-cache license boundary; workflow triggers, permissions, inputs, and release behavior are unchanged.

Verified that every pinned action declares the Node 24 runtime, all existing inputs remain available, the shared pins match, and the diff passes whitespace validation.

Closes #410.