### PR TITLE
feat: first-class CRON scheduling in the nodehost

### DIFF
--- a/nodel-framework/build.gradle
+++ b/nodel-framework/build.gradle
@@ -46,6 +46,15 @@ dependencies {
     implementation 'joda-time:joda-time:2.14.0'
     implementation 'org.slf4j:slf4j-api:1.7.10'
 
+    // CRON expression parsing, validation, descriptions and execution-time calculation
+    // (see org.nodel.cron). Its declared slf4j-api is 2.x which must not leak in: the host
+    // ships a 1.7-style binding (org.slf4j.impl.StaticLoggerBinder) that slf4j-api 2.x
+    // silently ignores. cron-utils only calls 1.7-era Logger/LoggerFactory methods, so
+    // running it against the project's pinned 1.7.10 API is safe.
+    implementation('com.cronutils:cron-utils:9.2.1') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+
     // SSH features
     implementation group: 'com.jcraft', name: 'jsch', version: '0.1.55'
 

--- a/nodel-framework/src/main/java/org/nodel/cron/CronExpressions.java
+++ b/nodel-framework/src/main/java/org/nodel/cron/CronExpressions.java
@@ -37,24 +37,50 @@ import com.cronutils.parser.CronParser;
 public class CronExpressions {
 
     /**
+     * Keeps parser and descriptor work bounded for network-facing callers.
+     */
+    public static final int MAX_EXPRESSION_LENGTH = 512;
+
+    /**
+     * Keeps timezone lookup and validation responses bounded.
+     */
+    public static final int MAX_TIME_ZONE_LENGTH = 128;
+
+    /**
+     * Framework-owned compiled form so cron-utils remains an implementation detail.
+     */
+    public static final class CompiledExpression {
+
+        private final Cron _cron;
+
+        private CompiledExpression(Cron cron) {
+            _cron = cron;
+        }
+
+    }
+
+    /**
      * (standard five-field UNIX crontab, Sunday as 0 or 7)
      */
-    private static CronDefinition s_definition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
+    private static final CronDefinition s_definition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
 
     /**
      * (thread-safe)
      */
-    private static CronParser s_parser = new CronParser(s_definition);
+    private static final CronParser s_parser = new CronParser(s_definition);
 
     /**
      * Parses and validates an expression, throwing with a friendly message on failure.
      */
-    public static Cron parse(String expression) {
+    public static CompiledExpression parse(String expression) {
+        if (expression != null && expression.length() > MAX_EXPRESSION_LENGTH)
+            throw new IllegalArgumentException("CRON expression is too long (maximum " + MAX_EXPRESSION_LENGTH + " characters).");
+
         if (Strings.isBlank(expression))
             throw new IllegalArgumentException("No CRON expression was provided.");
 
         try {
-            return s_parser.parse(expression.trim()).validate();
+            return new CompiledExpression(s_parser.parse(expression.trim()).validate());
 
         } catch (IllegalArgumentException exc) {
             throw new IllegalArgumentException("Invalid CRON expression - " + friendlyMessage(exc), exc);
@@ -92,8 +118,8 @@ public class CronExpressions {
     /**
      * (as above, for an already-parsed expression)
      */
-    public static String describe(Cron cron) {
-        return CronDescriptor.instance(Locale.ENGLISH).describe(cron);
+    public static String describe(CompiledExpression expression) {
+        return CronDescriptor.instance(Locale.ENGLISH).describe(expression._cron);
     }
 
     /**
@@ -101,6 +127,9 @@ public class CronExpressions {
      * (throws IllegalArgumentException when unknown)
      */
     public static ZoneId resolveTimeZone(String timeZone) {
+        if (timeZone != null && timeZone.length() > MAX_TIME_ZONE_LENGTH)
+            throw new IllegalArgumentException("Timezone is too long (maximum " + MAX_TIME_ZONE_LENGTH + " characters).");
+
         if (Strings.isBlank(timeZone))
             return ZoneId.systemDefault();
 
@@ -115,8 +144,8 @@ public class CronExpressions {
     /**
      * The next occurrence strictly after 'from' (or null if the expression can never fire e.g. 'Feb 30').
      */
-    public static ZonedDateTime nextOccurrence(Cron cron, ZonedDateTime from) {
-        return nextOccurrence(ExecutionTime.forCron(cron), from);
+    public static ZonedDateTime nextOccurrence(CompiledExpression expression, ZonedDateTime from) {
+        return nextOccurrence(ExecutionTime.forCron(expression._cron), from);
     }
 
     /**
@@ -130,8 +159,8 @@ public class CronExpressions {
     /**
      * The most recent occurrence strictly before 'from' (or null).
      */
-    public static ZonedDateTime previousOccurrence(Cron cron, ZonedDateTime from) {
-        return previousOccurrence(ExecutionTime.forCron(cron), from);
+    public static ZonedDateTime previousOccurrence(CompiledExpression expression, ZonedDateTime from) {
+        return previousOccurrence(ExecutionTime.forCron(expression._cron), from);
     }
 
     /**
@@ -147,7 +176,7 @@ public class CronExpressions {
      * (throws IllegalArgumentException on an invalid expression or timezone)
      */
     public static DateTime nextExecution(String expression, String timeZone) {
-        Cron cron = parse(expression);
+        CompiledExpression cron = parse(expression);
         ZoneId zone = resolveTimeZone(timeZone);
         return toDateTime(nextOccurrence(cron, ZonedDateTime.now(zone)));
     }
@@ -157,7 +186,7 @@ public class CronExpressions {
      * (throws IllegalArgumentException on an invalid expression or timezone)
      */
     public static DateTime previousExecution(String expression, String timeZone) {
-        Cron cron = parse(expression);
+        CompiledExpression cron = parse(expression);
         ZoneId zone = resolveTimeZone(timeZone);
         return toDateTime(previousOccurrence(cron, ZonedDateTime.now(zone)));
     }
@@ -168,9 +197,10 @@ public class CronExpressions {
      */
     public static CronInfo summarize(String expression, String timeZone) {
         CronInfo info = new CronInfo();
-        info.expression = expression;
+        if (expression == null || expression.length() <= MAX_EXPRESSION_LENGTH)
+            info.expression = expression;
 
-        Cron cron;
+        CompiledExpression cron;
         ZoneId zone;
         try {
             cron = parse(expression);
@@ -190,7 +220,7 @@ public class CronExpressions {
             // never let a description quirk break the summary
         }
 
-        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+        ExecutionTime executionTime = ExecutionTime.forCron(cron._cron);
 
         ZonedDateTime now = ZonedDateTime.now(zone);
         info.previous = toDateTime(previousOccurrence(executionTime, now));

--- a/nodel-framework/src/main/java/org/nodel/cron/CronExpressions.java
+++ b/nodel-framework/src/main/java/org/nodel/cron/CronExpressions.java
@@ -1,0 +1,249 @@
+package org.nodel.cron;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.nodel.Strings;
+
+import com.cronutils.descriptor.CronDescriptor;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+
+/**
+ * The authoritative CRON expression support for the host: parsing, validation,
+ * human-readable descriptions and previous / next execution-time calculation.
+ *
+ * Standard five-field UNIX expressions apply — minute, hour, day-of-month, month,
+ * day-of-week — including names (e.g. 'MON', 'JAN') and Sunday as 0 or 7. The host
+ * timezone applies unless an IANA timezone (e.g. 'Australia/Melbourne') is given.
+ *
+ * Occurrences that fall inside a daylight-saving gap are skipped; an occurrence that
+ * wall-clock time visits twice (daylight-saving overlap) applies once, at the first pass.
+ */
+public class CronExpressions {
+
+    /**
+     * (standard five-field UNIX crontab, Sunday as 0 or 7)
+     */
+    private static CronDefinition s_definition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
+
+    /**
+     * (thread-safe)
+     */
+    private static CronParser s_parser = new CronParser(s_definition);
+
+    /**
+     * Parses and validates an expression, throwing with a friendly message on failure.
+     */
+    public static Cron parse(String expression) {
+        if (Strings.isBlank(expression))
+            throw new IllegalArgumentException("No CRON expression was provided.");
+
+        try {
+            return s_parser.parse(expression.trim()).validate();
+
+        } catch (IllegalArgumentException exc) {
+            throw new IllegalArgumentException("Invalid CRON expression - " + friendlyMessage(exc), exc);
+        }
+    }
+
+    /**
+     * Whether an expression parses and validates.
+     */
+    public static boolean isValid(String expression) {
+        return validate(expression) == null;
+    }
+
+    /**
+     * Returns null when the expression is valid, otherwise the failure reason.
+     */
+    public static String validate(String expression) {
+        try {
+            parse(expression);
+            return null;
+
+        } catch (IllegalArgumentException exc) {
+            return exc.getMessage();
+        }
+    }
+
+    /**
+     * A human-readable description of a valid expression e.g. 'at 09:00 every day between Monday and Friday'.
+     * (throws IllegalArgumentException when invalid)
+     */
+    public static String describe(String expression) {
+        return describe(parse(expression));
+    }
+
+    /**
+     * (as above, for an already-parsed expression)
+     */
+    public static String describe(Cron cron) {
+        return CronDescriptor.instance(Locale.ENGLISH).describe(cron);
+    }
+
+    /**
+     * Resolves an optional IANA timezone, falling back to the host timezone.
+     * (throws IllegalArgumentException when unknown)
+     */
+    public static ZoneId resolveTimeZone(String timeZone) {
+        if (Strings.isBlank(timeZone))
+            return ZoneId.systemDefault();
+
+        try {
+            return ZoneId.of(timeZone.trim());
+
+        } catch (Exception exc) {
+            throw new IllegalArgumentException("Unknown timezone '" + timeZone.trim() + "' - an IANA timezone like 'Australia/Melbourne' is expected.");
+        }
+    }
+
+    /**
+     * The next occurrence strictly after 'from' (or null if the expression can never fire e.g. 'Feb 30').
+     */
+    public static ZonedDateTime nextOccurrence(Cron cron, ZonedDateTime from) {
+        return nextOccurrence(ExecutionTime.forCron(cron), from);
+    }
+
+    /**
+     * (as above, reusing an ExecutionTime — construction is not cheap so batch queries should share one)
+     */
+    private static ZonedDateTime nextOccurrence(ExecutionTime executionTime, ZonedDateTime from) {
+        Optional<ZonedDateTime> next = executionTime.nextExecution(from);
+        return next.isPresent() ? next.get() : null;
+    }
+
+    /**
+     * The most recent occurrence strictly before 'from' (or null).
+     */
+    public static ZonedDateTime previousOccurrence(Cron cron, ZonedDateTime from) {
+        return previousOccurrence(ExecutionTime.forCron(cron), from);
+    }
+
+    /**
+     * (as above, reusing an ExecutionTime)
+     */
+    private static ZonedDateTime previousOccurrence(ExecutionTime executionTime, ZonedDateTime from) {
+        Optional<ZonedDateTime> previous = executionTime.lastExecution(from);
+        return previous.isPresent() ? previous.get() : null;
+    }
+
+    /**
+     * The next execution after now (or null), e.g. for recipe use.
+     * (throws IllegalArgumentException on an invalid expression or timezone)
+     */
+    public static DateTime nextExecution(String expression, String timeZone) {
+        Cron cron = parse(expression);
+        ZoneId zone = resolveTimeZone(timeZone);
+        return toDateTime(nextOccurrence(cron, ZonedDateTime.now(zone)));
+    }
+
+    /**
+     * The most recent execution before now (or null), e.g. for recipe use.
+     * (throws IllegalArgumentException on an invalid expression or timezone)
+     */
+    public static DateTime previousExecution(String expression, String timeZone) {
+        Cron cron = parse(expression);
+        ZoneId zone = resolveTimeZone(timeZone);
+        return toDateTime(previousOccurrence(cron, ZonedDateTime.now(zone)));
+    }
+
+    /**
+     * A full, never-throwing summary for UI consumers — validity, description,
+     * effective timezone and previous / upcoming execution times.
+     */
+    public static CronInfo summarize(String expression, String timeZone) {
+        CronInfo info = new CronInfo();
+        info.expression = expression;
+
+        Cron cron;
+        ZoneId zone;
+        try {
+            cron = parse(expression);
+            zone = resolveTimeZone(timeZone);
+
+        } catch (IllegalArgumentException exc) {
+            info.error = exc.getMessage();
+            return info;
+        }
+
+        info.valid = true;
+        info.timeZone = zone.getId();
+
+        try {
+            info.description = describe(cron);
+        } catch (Exception exc) {
+            // never let a description quirk break the summary
+        }
+
+        ExecutionTime executionTime = ExecutionTime.forCron(cron);
+
+        ZonedDateTime now = ZonedDateTime.now(zone);
+        info.previous = toDateTime(previousOccurrence(executionTime, now));
+
+        ZonedDateTime next = nextOccurrence(executionTime, now);
+        info.next = toDateTime(next);
+
+        if (next != null) {
+            DateTime[] upcoming = new DateTime[CronInfo.UPCOMING_COUNT];
+            upcoming[0] = info.next;
+
+            ZonedDateTime occurrence = next;
+            for (int i = 1; i < CronInfo.UPCOMING_COUNT && occurrence != null; i++) {
+                occurrence = nextOccurrence(executionTime, occurrence);
+                upcoming[i] = toDateTime(occurrence);
+            }
+            info.upcoming = upcoming;
+        }
+
+        return info;
+    }
+
+    /**
+     * (java.time to the JODATIME convention used throughout the framework)
+     */
+    public static DateTime toDateTime(ZonedDateTime value) {
+        if (value == null)
+            return null;
+
+        DateTimeZone zone;
+        try {
+            zone = DateTimeZone.forID(value.getZone().getId());
+
+        } catch (IllegalArgumentException exc) {
+            // the JODATIME database may trail java.time; preserve the instant using a fixed offset
+            zone = DateTimeZone.forOffsetMillis(value.getOffset().getTotalSeconds() * 1000);
+        }
+
+        return new DateTime(value.toInstant().toEpochMilli(), zone);
+    }
+
+    /**
+     * (strips the exception-class prefixes cron-utils nests into its messages)
+     */
+    private static String friendlyMessage(Exception exc) {
+        String message = exc.getMessage();
+        if (Strings.isBlank(message))
+            return "could not be parsed.";
+
+        // e.g. "Failed to parse cron expression. Value 60 not in range [0, 59]"
+        return message.replace("Failed to parse cron expression. ", "")
+                      .replace("cron expression contains", "expression contains")
+                      .replace("Cron expression contains", "expression contains");
+    }
+
+}

--- a/nodel-framework/src/main/java/org/nodel/cron/CronInfo.java
+++ b/nodel-framework/src/main/java/org/nodel/cron/CronInfo.java
@@ -1,0 +1,47 @@
+package org.nodel.cron;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import org.joda.time.DateTime;
+import org.nodel.reflection.Value;
+
+/**
+ * A serialisable summary of a CRON expression for UI and REST consumers.
+ * (see CronExpressions.summarize)
+ */
+public class CronInfo {
+
+    /**
+     * The number of execution times carried by 'upcoming'.
+     */
+    public final static int UPCOMING_COUNT = 5;
+
+    @Value(name = "expression", order = 1, title = "Expression", desc = "The five-field UNIX CRON expression, as provided.", required = false)
+    public String expression;
+
+    @Value(name = "valid", order = 2, title = "Valid", desc = "Whether the expression parsed and validated.")
+    public boolean valid;
+
+    @Value(name = "error", order = 3, title = "Error", desc = "The failure reason when not valid.", required = false)
+    public String error;
+
+    @Value(name = "description", order = 4, title = "Description", desc = "A human-readable description of the schedule.", required = false)
+    public String description;
+
+    @Value(name = "timeZone", order = 5, title = "Timezone", desc = "The effective IANA timezone.", required = false)
+    public String timeZone;
+
+    @Value(name = "previous", order = 6, title = "Previous", desc = "The most recent execution time before now (if any).", required = false)
+    public DateTime previous;
+
+    @Value(name = "next", order = 7, title = "Next", desc = "The next execution time (absent when the schedule can never fire).", required = false)
+    public DateTime next;
+
+    @Value(name = "upcoming", order = 8, title = "Upcoming", desc = "The next few execution times, starting with 'next'.", required = false, genericClassA = DateTime.class)
+    public DateTime[] upcoming;
+
+}

--- a/nodel-framework/src/main/java/org/nodel/host/BaseNode.java
+++ b/nodel-framework/src/main/java/org/nodel/host/BaseNode.java
@@ -27,6 +27,8 @@ import org.nodel.core.NodelClientEvent;
 import org.nodel.core.NodelServerAction;
 import org.nodel.core.NodelServerEvent;
 import org.nodel.core.NodelClients.NodeURL;
+import org.nodel.cron.CronExpressions;
+import org.nodel.cron.CronInfo;
 import org.nodel.discovery.AdvertisementInfo;
 import org.nodel.discovery.AutoDNS;
 import org.nodel.host.LogEntry.Source;
@@ -1019,7 +1021,14 @@ public abstract class BaseNode implements Closeable {
             @Param(name = "filter", title = "Filter", desc = "Optional string filter.") String filter) throws IOException {
         return Nodel.getNodeURLs(filter);
     }
-    
+
+    @Service(name = "cron", order = 7, title = "Cron", desc = "CRON expression support - validation, description and execution times.")
+    public CronInfo cron(
+            @Param(name = "expression", title = "Expression", desc = "A five-field UNIX CRON expression.") String expression,
+            @Param(name = "timezone", title = "Timezone", desc = "An optional IANA timezone e.g. 'Australia/Melbourne' (the host timezone applies otherwise).") String timezone) {
+        return CronExpressions.summarize(expression, timezone);
+    }
+
     /**
      * Must be called by subclasses
      */

--- a/nodel-framework/src/main/java/org/nodel/toolkit/ManagedCron.java
+++ b/nodel-framework/src/main/java/org/nodel/toolkit/ManagedCron.java
@@ -16,12 +16,11 @@ import org.joda.time.DateTime;
 import org.nodel.Handler.H0;
 import org.nodel.Handler.H1;
 import org.nodel.cron.CronExpressions;
+import org.nodel.cron.CronExpressions.CompiledExpression;
 import org.nodel.threading.CallbackQueue;
 import org.nodel.threading.ThreadPool;
 import org.nodel.threading.TimerTask;
 import org.nodel.threading.Timers;
-
-import com.cronutils.model.Cron;
 
 /**
  * A managed CRON schedule (see CronExpressions for the expression rules), sharing the
@@ -88,7 +87,7 @@ public class ManagedCron implements Closeable {
     /**
      * (parsed and validated form of '_expression')
      */
-    private Cron _cron;
+    private CompiledExpression _cron;
 
     /**
      * The effective timezone (the host timezone unless one was provided).
@@ -109,6 +108,22 @@ public class ManagedCron implements Closeable {
      * The instant (millis) the pending task is aimed at (0 when none is pending).
      */
     private long _nextFireMillis;
+
+    /**
+     * Identifies the currently configured timer generation. Any lifecycle or
+     * configuration change invalidates work queued by an earlier generation.
+     */
+    private long _generation;
+
+    /**
+     * The generation currently admitted to the callback queue (0 when idle).
+     */
+    private long _activeGeneration;
+
+    /**
+     * The physical target of the callback currently in progress.
+     */
+    private long _activeTargetMillis;
 
     /**
      * When the callback actually last fired (null if never).
@@ -149,21 +164,37 @@ public class ManagedCron implements Closeable {
     }
 
     /**
-     * Schedules the next occurrence strictly after 'from' (lock must be held).
+     * Invalidates queued work and clears the pending physical timer (lock must be held).
      */
-    private void scheduleNext(ZonedDateTime from) {
+    private long invalidatePendingSchedule() {
         if (_timerTask != null)
             _timerTask.cancel();
 
         _timerTask = null;
         _nextFireMillis = 0;
 
+        return ++_generation;
+    }
+
+    /**
+     * Whether work from a generation can still be admitted or rearmed (lock must be held).
+     */
+    private boolean isCurrent(long generation) {
+        return !_shutdown && _started && _generation == generation;
+    }
+
+    /**
+     * Schedules the next occurrence strictly after 'from' (lock must be held).
+     */
+    private void scheduleNext(ZonedDateTime from) {
+        final long generation = invalidatePendingSchedule();
+
         ZonedDateTime next = CronExpressions.nextOccurrence(_cron, from);
         if (next == null)
             // can never fire (e.g. 'Feb 30'); remains started but dormant
             return;
 
-        long target = next.toInstant().toEpochMilli();
+        final long target = next.toInstant().toEpochMilli();
         _nextFireMillis = target;
 
         final TimerTask timerTask = new TimerTask() {
@@ -172,13 +203,9 @@ public class ManagedCron implements Closeable {
 
             @Override
             public void run() {
-                long target;
-
                 synchronized (_lock) {
-                    if (_shutdown || _self.isCancelled() || !_started)
+                    if (!isCurrent(generation) || _self.isCancelled())
                         return;
-
-                    target = _nextFireMillis;
 
                     long now = currentTimeMillis();
                     if (target - now > EARLY_FIRE_TOLERANCE) {
@@ -193,20 +220,40 @@ public class ManagedCron implements Closeable {
 
                     @Override
                     public void run() {
+                        _callbackQueue.handle(new H0() {
+
+                            @Override
+                            public void handle() {
+                                synchronized (_lock) {
+                                    if (!isCurrent(generation) || _self.isCancelled())
+                                        return;
+
+                                    // This is the admission point. A stop, close or
+                                    // reconfiguration before it drops the stale callback;
+                                    // after it, the callback may finish but cannot rearm.
+                                    _timerTask = null;
+                                    _nextFireMillis = 0;
+                                    _activeGeneration = generation;
+                                    _activeTargetMillis = target;
+
+                                    long firedAt = currentTimeMillis();
+                                    _lastFired = CronExpressions.toDateTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(firedAt), _zone));
+                                }
+
+                                _threadStateHandler.handle();
+                                _callback.handle();
+                            }
+
+                        }, _exceptionHandler);
+
                         synchronized (_lock) {
-                            if (_shutdown || _self.isCancelled() || !_started)
+                            if (_activeGeneration == generation) {
+                                _activeGeneration = 0;
+                                _activeTargetMillis = 0;
+                            }
+
+                            if (!isCurrent(generation) || _self.isCancelled())
                                 return;
-                        }
-
-                        _threadStateHandler.handle();
-
-                        _callbackQueue.handle(_callback, _exceptionHandler);
-
-                        synchronized (_lock) {
-                            if (_shutdown || _self.isCancelled() || !_started)
-                                return;
-
-                            _lastFired = DateTime.now();
 
                             // next occurrence from the later of 'now' and the target just fired:
                             // coalesces any occurrences missed while delayed and can never
@@ -243,12 +290,8 @@ public class ManagedCron implements Closeable {
      */
     public void stop() {
         synchronized (_lock) {
-            if (_timerTask != null)
-                _timerTask.cancel();
-
-            _timerTask = null;
-            _nextFireMillis = 0;
             _started = false;
+            invalidatePendingSchedule();
         }
     }
 
@@ -257,7 +300,7 @@ public class ManagedCron implements Closeable {
      * the previous schedule remains in place on failure).
      */
     public void setExpression(String expression) {
-        Cron cron = CronExpressions.parse(expression);
+        CompiledExpression cron = CronExpressions.parse(expression);
 
         synchronized (_lock) {
             _cron = cron;
@@ -265,6 +308,8 @@ public class ManagedCron implements Closeable {
 
             if (_started)
                 scheduleNext(now());
+            else
+                invalidatePendingSchedule();
         }
     }
 
@@ -286,6 +331,8 @@ public class ManagedCron implements Closeable {
 
             if (_started)
                 scheduleNext(now());
+            else
+                invalidatePendingSchedule();
         }
     }
 
@@ -311,12 +358,29 @@ public class ManagedCron implements Closeable {
      * When this schedule will next fire (null when stopped or when it can never fire).
      */
     public DateTime getNextExecution() {
+        CompiledExpression cron;
+        ZoneId zone;
+        long basisMillis;
+
         synchronized (_lock) {
-            if (_nextFireMillis == 0)
+            if (!_started)
                 return null;
 
-            return CronExpressions.toDateTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(_nextFireMillis), _zone));
+            if (_nextFireMillis != 0)
+                return CronExpressions.toDateTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(_nextFireMillis), _zone));
+
+            if (_activeGeneration != _generation)
+                return null;
+
+            cron = _cron;
+            zone = _zone;
+            basisMillis = Math.max(currentTimeMillis(), _activeTargetMillis);
         }
+
+        // No next physical timer is armed until the callback completes, preserving
+        // coalescing and non-overlap while still exposing the logical next occurrence.
+        ZonedDateTime basis = ZonedDateTime.ofInstant(Instant.ofEpochMilli(basisMillis), zone);
+        return CronExpressions.toDateTime(CronExpressions.nextOccurrence(cron, basis));
     }
 
     /**
@@ -324,7 +388,7 @@ public class ManagedCron implements Closeable {
      * whether the schedule was running at the time (null if none).
      */
     public DateTime getPreviousExecution() {
-        Cron cron;
+        CompiledExpression cron;
         ZonedDateTime from;
         synchronized (_lock) {
             cron = _cron;
@@ -372,10 +436,7 @@ public class ManagedCron implements Closeable {
 
             _shutdown = true;
             _started = false;
-            _nextFireMillis = 0;
-
-            if (_timerTask != null)
-                _timerTask.cancel();
+            invalidatePendingSchedule();
         }
     }
 

--- a/nodel-framework/src/main/java/org/nodel/toolkit/ManagedCron.java
+++ b/nodel-framework/src/main/java/org/nodel/toolkit/ManagedCron.java
@@ -1,0 +1,382 @@
+package org.nodel.toolkit;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.joda.time.DateTime;
+import org.nodel.Handler.H0;
+import org.nodel.Handler.H1;
+import org.nodel.cron.CronExpressions;
+import org.nodel.threading.CallbackQueue;
+import org.nodel.threading.ThreadPool;
+import org.nodel.threading.TimerTask;
+import org.nodel.threading.Timers;
+
+import com.cronutils.model.Cron;
+
+/**
+ * A managed CRON schedule (see CronExpressions for the expression rules), sharing the
+ * pooled timer infrastructure — no dedicated thread per schedule.
+ *
+ * Each fire schedules the next occurrence. A fire that arrives late (e.g. after system
+ * suspension or heavy load) still occurs once while the host remains running; occurrences
+ * missed in the meantime are coalesced into it, never replayed. A schedule created after
+ * a host or node restart looks forward only.
+ */
+public class ManagedCron implements Closeable {
+
+    /**
+     * When a fire arrives earlier than this ahead of its target (e.g. wall-clock
+     * adjustment), the remainder is re-slept instead of firing.
+     */
+    private final static long EARLY_FIRE_TOLERANCE = 500;
+
+    private Object _lock = new Object();
+
+    private boolean _shutdown;
+
+    /**
+     * The shared timer thread (must minimise time spent on this thread)
+     */
+    private Timers _timerThread;
+
+    /**
+     * A shared thread pool to use.
+     */
+    private ThreadPool _threadPool;
+
+    /**
+     * When unhandled exceptions occur
+     */
+    private H1<Exception> _exceptionHandler;
+
+    /**
+     * Callback queue
+     */
+    private CallbackQueue _callbackQueue;
+
+    /**
+     * The registered callback (fixed for this schedule)
+     */
+    private H0 _callback;
+
+    /**
+     * Sets up the thread state.
+     */
+    private H0 _threadStateHandler;
+
+    /**
+     * Do not start on creation
+     * (carries flag only, not used within this class)
+     */
+    private boolean _stoppedAtFirst;
+
+    /**
+     * The expression, as provided.
+     */
+    private String _expression;
+
+    /**
+     * (parsed and validated form of '_expression')
+     */
+    private Cron _cron;
+
+    /**
+     * The effective timezone (the host timezone unless one was provided).
+     */
+    private ZoneId _zone;
+
+    /**
+     * Holds the current timer task
+     */
+    private TimerTask _timerTask;
+
+    /**
+     * Whether the schedule is running.
+     */
+    private boolean _started;
+
+    /**
+     * The instant (millis) the pending task is aimed at (0 when none is pending).
+     */
+    private long _nextFireMillis;
+
+    /**
+     * When the callback actually last fired (null if never).
+     */
+    private DateTime _lastFired;
+
+    /**
+     * (throws IllegalArgumentException on an invalid expression or timezone)
+     */
+    public ManagedCron(H0 callback, String expression, String timeZone, boolean stoppedAtFirst, H0 threadStateHandler, Timers timerThreads, ThreadPool threadPool, H1<Exception> exceptionHandler, CallbackQueue callbackQueue) {
+        _threadStateHandler = threadStateHandler;
+        _timerThread = timerThreads;
+        _threadPool = threadPool;
+        _exceptionHandler = exceptionHandler;
+        _callbackQueue = callbackQueue;
+
+        _stoppedAtFirst = stoppedAtFirst;
+        _callback = callback;
+
+        _cron = CronExpressions.parse(expression);
+        _expression = expression.trim();
+
+        _zone = CronExpressions.resolveTimeZone(timeZone);
+    }
+
+    /**
+     * The wall-clock (overridable for deterministic testing).
+     */
+    protected long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+
+    /**
+     * ('currentTimeMillis' as a zoned timestamp)
+     */
+    private ZonedDateTime now() {
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(currentTimeMillis()), _zone);
+    }
+
+    /**
+     * Schedules the next occurrence strictly after 'from' (lock must be held).
+     */
+    private void scheduleNext(ZonedDateTime from) {
+        if (_timerTask != null)
+            _timerTask.cancel();
+
+        _timerTask = null;
+        _nextFireMillis = 0;
+
+        ZonedDateTime next = CronExpressions.nextOccurrence(_cron, from);
+        if (next == null)
+            // can never fire (e.g. 'Feb 30'); remains started but dormant
+            return;
+
+        long target = next.toInstant().toEpochMilli();
+        _nextFireMillis = target;
+
+        final TimerTask timerTask = new TimerTask() {
+
+            TimerTask _self = this;
+
+            @Override
+            public void run() {
+                long target;
+
+                synchronized (_lock) {
+                    if (_shutdown || _self.isCancelled() || !_started)
+                        return;
+
+                    target = _nextFireMillis;
+
+                    long now = currentTimeMillis();
+                    if (target - now > EARLY_FIRE_TOLERANCE) {
+                        // woke early (e.g. wall-clock adjusted backwards); sleep out the remainder
+                        _timerThread.schedule(_self, target - now);
+                        return;
+                    }
+                }
+
+                // callback can block so execute on a thread-pool
+                _threadPool.execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        synchronized (_lock) {
+                            if (_shutdown || _self.isCancelled() || !_started)
+                                return;
+                        }
+
+                        _threadStateHandler.handle();
+
+                        _callbackQueue.handle(_callback, _exceptionHandler);
+
+                        synchronized (_lock) {
+                            if (_shutdown || _self.isCancelled() || !_started)
+                                return;
+
+                            _lastFired = DateTime.now();
+
+                            // next occurrence from the later of 'now' and the target just fired:
+                            // coalesces any occurrences missed while delayed and can never
+                            // re-fire the occurrence that just completed
+                            long basis = Math.max(currentTimeMillis(), target);
+                            scheduleNext(ZonedDateTime.ofInstant(Instant.ofEpochMilli(basis), _zone));
+                        }
+                    }
+
+                }); // (.execute)
+            }
+
+        }; // (new TimerTask)
+
+        _timerTask = _timerThread.schedule(timerTask, Math.max(1, target - currentTimeMillis()));
+    }
+
+    /**
+     * Starts the schedule if it hasn't already been started.
+     */
+    public void start() {
+        synchronized (_lock) {
+            if (_shutdown || _started)
+                return;
+
+            _started = true;
+
+            scheduleNext(now());
+        }
+    }
+
+    /**
+     * Stops / pauses / suspends this schedule.
+     */
+    public void stop() {
+        synchronized (_lock) {
+            if (_timerTask != null)
+                _timerTask.cancel();
+
+            _timerTask = null;
+            _nextFireMillis = 0;
+            _started = false;
+        }
+    }
+
+    /**
+     * Reconfigures the expression (throws IllegalArgumentException when invalid;
+     * the previous schedule remains in place on failure).
+     */
+    public void setExpression(String expression) {
+        Cron cron = CronExpressions.parse(expression);
+
+        synchronized (_lock) {
+            _cron = cron;
+            _expression = expression.trim();
+
+            if (_started)
+                scheduleNext(now());
+        }
+    }
+
+    public String getExpression() {
+        synchronized (_lock) {
+            return _expression;
+        }
+    }
+
+    /**
+     * Reconfigures the timezone — an IANA timezone, or null / empty for the host timezone
+     * (throws IllegalArgumentException when unknown; the previous schedule remains in place on failure).
+     */
+    public void setTimeZone(String timeZone) {
+        ZoneId zone = CronExpressions.resolveTimeZone(timeZone);
+
+        synchronized (_lock) {
+            _zone = zone;
+
+            if (_started)
+                scheduleNext(now());
+        }
+    }
+
+    /**
+     * The effective IANA timezone.
+     */
+    public String getTimeZone() {
+        synchronized (_lock) {
+            return _zone.getId();
+        }
+    }
+
+    /**
+     * A human-readable description of the schedule.
+     */
+    public String getDescription() {
+        synchronized (_lock) {
+            return CronExpressions.describe(_cron);
+        }
+    }
+
+    /**
+     * When this schedule will next fire (null when stopped or when it can never fire).
+     */
+    public DateTime getNextExecution() {
+        synchronized (_lock) {
+            if (_nextFireMillis == 0)
+                return null;
+
+            return CronExpressions.toDateTime(ZonedDateTime.ofInstant(Instant.ofEpochMilli(_nextFireMillis), _zone));
+        }
+    }
+
+    /**
+     * The most recent occurrence of the expression before now, regardless of
+     * whether the schedule was running at the time (null if none).
+     */
+    public DateTime getPreviousExecution() {
+        Cron cron;
+        ZonedDateTime from;
+        synchronized (_lock) {
+            cron = _cron;
+            from = now();
+        }
+
+        // the backwards search can span a long calendar range for rarely-matching
+        // expressions, so it must not hold up the fire/reconfigure paths
+        return CronExpressions.toDateTime(CronExpressions.previousOccurrence(cron, from));
+    }
+
+    /**
+     * When the callback actually last fired (null if never).
+     */
+    public DateTime getLastFired() {
+        synchronized (_lock) {
+            return _lastFired;
+        }
+    }
+
+    /**
+     * Be stopped on creation
+     */
+    public boolean getStoppedAtFirst() {
+        return _stoppedAtFirst;
+    }
+
+    public boolean isStarted() {
+        synchronized (_lock) {
+            return _started;
+        }
+    }
+
+    public boolean isStopped() {
+        synchronized (_lock) {
+            return !_started;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (_lock) {
+            if (_shutdown)
+                return;
+
+            _shutdown = true;
+            _started = false;
+            _nextFireMillis = 0;
+
+            if (_timerTask != null)
+                _timerTask.cancel();
+        }
+    }
+
+}

--- a/nodel-framework/src/main/java/org/nodel/toolkit/ManagedToolkit.java
+++ b/nodel-framework/src/main/java/org/nodel/toolkit/ManagedToolkit.java
@@ -24,6 +24,7 @@ import org.nodel.core.NodelClientEvent;
 import org.nodel.core.NodelEventHandler;
 import org.nodel.core.NodelServerAction;
 import org.nodel.core.NodelServerEvent;
+import org.nodel.cron.CronExpressions;
 import org.nodel.host.BaseDynamicNode;
 import org.nodel.host.Binding;
 import org.nodel.host.LogEntry;
@@ -119,6 +120,11 @@ public class ManagedToolkit {
      * ('exceptionHandler' with context)
      */
     private H1<Exception> _timerExceptionHandler = createExceptionHandlerWithContext("timer");
+
+    /**
+     * ('exceptionHandler' with context)
+     */
+    private H1<Exception> _cronExceptionHandler = createExceptionHandlerWithContext("cron");
     
     /**
      * ('exceptionHandler' with context)
@@ -175,6 +181,11 @@ public class ManagedToolkit {
      * All the managed timers.
      */
     private Set<ManagedTimer> _timers = new HashSet<ManagedTimer>();
+
+    /**
+     * All the managed CRON schedules.
+     */
+    private Set<ManagedCron> _crons = new HashSet<ManagedCron>();
     
     /**
      * Holds all the TCP connections
@@ -368,6 +379,80 @@ public class ManagedToolkit {
             }
             _timers.clear();
         }
+    }
+
+    /**
+     * Creates a managed CRON schedule (see ManagedCron).
+     * (throws IllegalArgumentException on an invalid expression or timezone)
+     */
+    public ManagedCron createCron(H0 func, String expression, String timeZone, boolean stopped) {
+        synchronized (_lock) {
+            if (_closed)
+                throw new IllegalStateException("Node is closed.");
+
+            // create a schedule (will be stopped)
+            ManagedCron cron = new ManagedCron(func, expression, timeZone, stopped, _threadStateHandler, s_timers, s_threadPool, _cronExceptionHandler, _callbackQueue);
+
+            _crons.add(cron);
+
+            // if created after normal init, start (if no 'stopped' flag)
+            if (_enabled && !stopped)
+                cron.start();
+
+            // otherwise .start() will be called from 'enable'
+
+            return cron;
+        }
+    }
+
+    /**
+     * Safely clears all created CRON schedules.
+     */
+    public void releaseCrons() {
+        synchronized (_lock) {
+            for (ManagedCron cron : _crons) {
+                Stream.safeClose(cron);
+            }
+            _crons.clear();
+        }
+    }
+
+    /**
+     * Returns null when a CRON expression is valid, otherwise the failure reason.
+     */
+    public String cronValidate(String expression) {
+        return CronExpressions.validate(expression);
+    }
+
+    /**
+     * Whether a CRON expression parses and validates.
+     */
+    public boolean cronIsValid(String expression) {
+        return CronExpressions.isValid(expression);
+    }
+
+    /**
+     * A human-readable description of a CRON expression.
+     * (throws IllegalArgumentException when invalid)
+     */
+    public String cronDescribe(String expression) {
+        return CronExpressions.describe(expression);
+    }
+
+    /**
+     * The next execution of a CRON expression after now, or null if it can never fire.
+     * (optional IANA timezone; throws IllegalArgumentException when invalid)
+     */
+    public DateTime cronNextExecution(String expression, String timeZone) {
+        return CronExpressions.nextExecution(expression, timeZone);
+    }
+
+    /**
+     * The most recent execution of a CRON expression before now, or null.
+     * (optional IANA timezone; throws IllegalArgumentException when invalid)
+     */
+    public DateTime cronPreviousExecution(String expression, String timeZone) {
+        return CronExpressions.previousExecution(expression, timeZone);
     }
     
     /**
@@ -928,6 +1013,12 @@ public class ManagedToolkit {
                 }
             }
 
+            for (ManagedCron cron : _crons) {
+                // start only those that haven't opted out
+                if (!cron.getStoppedAtFirst())
+                    cron.start();
+            }
+
             for (ManagedTCP tcp : _tcpConnections) {
                 tcp.start();
             }
@@ -1011,9 +1102,11 @@ public class ManagedToolkit {
             _closed = true;
 
             releaseCalls();
-            
+
             releaseTimers();
-            
+
+            releaseCrons();
+
             releaseTCPs();
             
             releaseUDPs();

--- a/nodel-framework/src/test/java/org/nodel/cron/CronExpressionsTest.java
+++ b/nodel-framework/src/test/java/org/nodel/cron/CronExpressionsTest.java
@@ -13,16 +13,18 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.nodel.GitHubIssue;
-
-import com.cronutils.model.Cron;
+import org.nodel.cron.CronExpressions.CompiledExpression;
 
 @GitHubIssue("https://github.com/museumsvictoria/nodel/issues/411")
 public class CronExpressionsTest {
@@ -92,6 +94,25 @@ public class CronExpressionsTest {
         assertTrue(CronExpressions.validate("* * * *").contains("4"));
     }
 
+    @Test
+    public void boundsExpressionWorkBeforeParsing() {
+        String accepted = String.join(",", Collections.nCopies(252, "0")) + " * * * *";
+        String rejected = String.join(",", Collections.nCopies(253, "0")) + " * * * *";
+
+        assertEquals(511, accepted.length());
+        assertTrue(CronExpressions.isValid(accepted));
+
+        assertEquals(513, rejected.length());
+        String error = CronExpressions.validate(rejected);
+        assertTrue(error.contains("maximum 512"));
+        assertFalse(error.contains(rejected));
+
+        CronInfo info = CronExpressions.summarize(rejected, null);
+        assertFalse(info.valid);
+        assertNull(info.expression);
+        assertTrue(info.error.length() < 128);
+    }
+
     // human-readable descriptions
 
     @Test
@@ -124,6 +145,39 @@ public class CronExpressionsTest {
     @Test
     public void rejectsUnknownTimezones() {
         assertThrows(IllegalArgumentException.class, () -> CronExpressions.resolveTimeZone("Mars/OlympusMons"));
+    }
+
+    @Test
+    public void rejectsOversizedTimezoneWithoutEchoingIt() {
+        String timeZone = String.join("", Collections.nCopies(CronExpressions.MAX_TIME_ZONE_LENGTH + 1, "A"));
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> CronExpressions.resolveTimeZone(timeZone));
+        assertTrue(error.getMessage().contains("maximum 128"));
+        assertFalse(error.getMessage().contains(timeZone));
+
+        CronInfo info = CronExpressions.summarize("* * * * *", timeZone);
+        assertFalse(info.valid);
+        assertTrue(info.error.length() < 128);
+    }
+
+    @Test
+    public void publicApiDoesNotExposeCronUtilsTypes() {
+        for (Method method : CronExpressions.class.getDeclaredMethods()) {
+            if (!Modifier.isPublic(method.getModifiers()))
+                continue;
+
+            assertFalse(isCronUtilsType(method.getReturnType()), method.toString());
+            for (Class<?> parameterType : method.getParameterTypes())
+                assertFalse(isCronUtilsType(parameterType), method.toString());
+        }
+    }
+
+    private static boolean isCronUtilsType(Class<?> type) {
+        while (type.isArray())
+            type = type.getComponentType();
+
+        return type.getName().startsWith("com.cronutils.");
     }
 
     // Sunday semantics: 0, 7 and 'SUN' are the same day
@@ -310,7 +364,7 @@ public class CronExpressionsTest {
 
     @Test
     public void parseTrimsWhitespace() {
-        Cron cron = CronExpressions.parse("  0 9 * * 1-5  ");
+        CompiledExpression cron = CronExpressions.parse("  0 9 * * 1-5  ");
         assertNotNull(cron);
     }
 

--- a/nodel-framework/src/test/java/org/nodel/cron/CronExpressionsTest.java
+++ b/nodel-framework/src/test/java/org/nodel/cron/CronExpressionsTest.java
@@ -1,0 +1,317 @@
+package org.nodel.cron;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.nodel.GitHubIssue;
+
+import com.cronutils.model.Cron;
+
+@GitHubIssue("https://github.com/museumsvictoria/nodel/issues/411")
+public class CronExpressionsTest {
+
+    private final static ZoneId MELBOURNE = ZoneId.of("Australia/Melbourne");
+
+    private final static ZoneId LONDON = ZoneId.of("Europe/London");
+
+    private static ZonedDateTime next(String expression, ZonedDateTime from) {
+        return CronExpressions.nextOccurrence(CronExpressions.parse(expression), from);
+    }
+
+    private static ZonedDateTime previous(String expression, ZonedDateTime from) {
+        return CronExpressions.previousOccurrence(CronExpressions.parse(expression), from);
+    }
+
+    // syntax and validation
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "* * * * *",
+            "0 9 * * 1-5",
+            "*/15 8-18 * * MON-FRI",
+            "0 0 1 JAN,JUL *",
+            "30 4 1,15 * 5",
+            "0 22 * * 0",
+            "0 22 * * 7",
+            "0 22 * * SUN",
+            "5 0 * 8 *",
+            "0 0 30 2 *",
+            "  * * * * *  " })
+    public void acceptsStandardFiveFieldExpressions(String expression) {
+        assertTrue(CronExpressions.isValid(expression), expression);
+        assertNull(CronExpressions.validate(expression), expression);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "   ",
+            "* * * *",
+            "* * * * * *",
+            "60 * * * *",
+            "* 24 * * *",
+            "* * 0 * *",
+            "* * * 13 *",
+            "* * * * 8",
+            "a b c d e",
+            "*/0 * * * *",
+            "1-5-7 * * * *",
+            "@daily" })
+    public void rejectsInvalidExpressions(String expression) {
+        assertFalse(CronExpressions.isValid(expression), expression);
+        assertNotNull(CronExpressions.validate(expression), expression);
+        assertThrows(IllegalArgumentException.class, () -> CronExpressions.parse(expression), expression);
+    }
+
+    @Test
+    public void rejectsNull() {
+        assertFalse(CronExpressions.isValid(null));
+        assertThrows(IllegalArgumentException.class, () -> CronExpressions.parse(null));
+    }
+
+    @Test
+    public void validationMessagesCarryTheReason() {
+        assertTrue(CronExpressions.validate("60 * * * *").contains("[0, 59]"));
+        assertTrue(CronExpressions.validate("* * * *").contains("4"));
+    }
+
+    // human-readable descriptions
+
+    @Test
+    public void describesCommonExpressions() {
+        assertEquals("every minute", CronExpressions.describe("* * * * *"));
+        assertEquals("at 09:00 every day between Monday and Friday", CronExpressions.describe("0 9 * * 1-5"));
+        assertEquals("every 5 minutes", CronExpressions.describe("*/5 * * * *"));
+    }
+
+    @Test
+    public void describeRejectsInvalidExpressions() {
+        assertThrows(IllegalArgumentException.class, () -> CronExpressions.describe("not a cron"));
+    }
+
+    // timezones
+
+    @Test
+    public void hostTimezoneAppliesByDefault() {
+        assertEquals(ZoneId.systemDefault(), CronExpressions.resolveTimeZone(null));
+        assertEquals(ZoneId.systemDefault(), CronExpressions.resolveTimeZone(""));
+        assertEquals(ZoneId.systemDefault(), CronExpressions.resolveTimeZone("  "));
+    }
+
+    @Test
+    public void resolvesIanaTimezones() {
+        assertEquals(MELBOURNE, CronExpressions.resolveTimeZone("Australia/Melbourne"));
+        assertEquals(LONDON, CronExpressions.resolveTimeZone(" Europe/London "));
+    }
+
+    @Test
+    public void rejectsUnknownTimezones() {
+        assertThrows(IllegalArgumentException.class, () -> CronExpressions.resolveTimeZone("Mars/OlympusMons"));
+    }
+
+    // Sunday semantics: 0, 7 and 'SUN' are the same day
+
+    @ParameterizedTest
+    @ValueSource(strings = { "0 22 * * 0", "0 22 * * 7", "0 22 * * SUN" })
+    public void sundayAcceptedAsZeroSevenOrName(String expression) {
+        // from a Saturday midday
+        ZonedDateTime saturday = ZonedDateTime.of(2026, 7, 18, 12, 0, 0, 0, MELBOURNE);
+
+        assertEquals(ZonedDateTime.of(2026, 7, 19, 22, 0, 0, 0, MELBOURNE), next(expression, saturday));
+        assertEquals(ZonedDateTime.of(2026, 7, 12, 22, 0, 0, 0, MELBOURNE), previous(expression, saturday));
+    }
+
+    // named months and weekdays
+
+    @Test
+    public void namedMonths() {
+        ZonedDateTime midJuly = ZonedDateTime.of(2026, 7, 16, 12, 0, 0, 0, MELBOURNE);
+        assertEquals(ZonedDateTime.of(2027, 1, 1, 0, 0, 0, 0, MELBOURNE), next("0 0 1 JAN *", midJuly));
+    }
+
+    @Test
+    public void namedWeekdays() {
+        // 2026-07-16 is a Thursday
+        ZonedDateTime thursday = ZonedDateTime.of(2026, 7, 16, 12, 0, 0, 0, MELBOURNE);
+        assertEquals(ZonedDateTime.of(2026, 7, 17, 9, 0, 0, 0, MELBOURNE), next("0 9 * * MON-FRI", thursday));
+        assertEquals(ZonedDateTime.of(2026, 7, 20, 9, 0, 0, 0, MELBOURNE), next("0 9 * * MON", thursday));
+    }
+
+    // previous / next calculation
+
+    @Test
+    public void nextIsStrictlyAfterAndPreviousStrictlyBefore() {
+        // from exactly an occurrence (Friday 09:00) neither direction returns that occurrence
+        ZonedDateTime friday9am = ZonedDateTime.of(2026, 7, 10, 9, 0, 0, 0, MELBOURNE);
+
+        assertEquals(ZonedDateTime.of(2026, 7, 13, 9, 0, 0, 0, MELBOURNE), next("0 9 * * MON-FRI", friday9am));
+        assertEquals(ZonedDateTime.of(2026, 7, 9, 9, 0, 0, 0, MELBOURNE), previous("0 9 * * MON-FRI", friday9am));
+    }
+
+    @Test
+    public void dayOfMonthAndDayOfWeekActAsAUnion() {
+        // standard UNIX CRON: when both are restricted, either match fires
+        // (2026-07-17 is a Friday, not the 13th)
+        ZonedDateTime thursday = ZonedDateTime.of(2026, 7, 16, 12, 0, 0, 0, MELBOURNE);
+        assertEquals(ZonedDateTime.of(2026, 7, 17, 0, 0, 0, 0, MELBOURNE), next("0 0 13 * FRI", thursday));
+    }
+
+    @Test
+    public void impossibleDateNeverFires() {
+        // February 30 is syntactically valid but has no occurrence
+        ZonedDateTime from = ZonedDateTime.of(2026, 7, 16, 12, 0, 0, 0, MELBOURNE);
+        assertNull(next("0 0 30 2 *", from));
+        assertNull(previous("0 0 30 2 *", from));
+    }
+
+    // daylight-saving transitions
+
+    @Test
+    public void dstGapSkipsNonexistentOccurrence() {
+        // Melbourne spring-forward 2026-10-04: 02:00 jumps to 03:00, so 02:30 never happens that day
+        ZonedDateTime beforeGap = ZonedDateTime.of(2026, 10, 3, 12, 0, 0, 0, MELBOURNE);
+
+        ZonedDateTime next = next("30 2 * * *", beforeGap);
+        assertEquals(ZonedDateTime.of(2026, 10, 5, 2, 30, 0, 0, MELBOURNE), next);
+        assertEquals("+11:00", next.getOffset().getId());
+    }
+
+    @Test
+    public void dstGapSkipsNonexistentOccurrenceNorthernHemisphere() {
+        // London spring-forward 2026-03-29: 01:00 jumps to 02:00, so 01:30 never happens that day
+        ZonedDateTime beforeGap = ZonedDateTime.of(2026, 3, 28, 12, 0, 0, 0, LONDON);
+
+        ZonedDateTime next = next("30 1 * * *", beforeGap);
+        assertEquals(ZonedDateTime.of(2026, 3, 30, 1, 30, 0, 0, LONDON), next);
+        assertEquals("+01:00", next.getOffset().getId());
+    }
+
+    @Test
+    public void dstOverlapFiresOnceAtTheFirstPass() {
+        // Melbourne fall-back 2026-04-05: 03:00 rewinds to 02:00, so wall-clock 02:30 happens twice;
+        // the occurrence applies once, at the first (daylight-saving) pass
+        ZonedDateTime beforeOverlap = ZonedDateTime.of(2026, 4, 4, 12, 0, 0, 0, MELBOURNE);
+
+        ZonedDateTime first = next("30 2 * * *", beforeOverlap);
+        assertEquals(ZonedDateTime.of(2026, 4, 5, 2, 30, 0, 0, MELBOURNE).withEarlierOffsetAtOverlap(), first);
+        assertEquals("+11:00", first.getOffset().getId());
+
+        // ... and the second wall-clock pass (+10:00) is not revisited
+        ZonedDateTime following = next("30 2 * * *", first);
+        assertEquals(ZonedDateTime.of(2026, 4, 6, 2, 30, 0, 0, MELBOURNE), following);
+        assertEquals("+10:00", following.getOffset().getId());
+    }
+
+    // convenience (recipe-facing) calculations
+
+    @Test
+    public void nextAndPreviousExecutionUseTheGivenTimezone() {
+        DateTime next = CronExpressions.nextExecution("* * * * *", "Australia/Melbourne");
+        assertNotNull(next);
+        assertTrue(next.isAfterNow());
+
+        DateTime previous = CronExpressions.previousExecution("* * * * *", "Australia/Melbourne");
+        assertNotNull(previous);
+        assertTrue(previous.isBeforeNow());
+    }
+
+    @Test
+    public void nextExecutionRejectsInvalidInput() {
+        assertThrows(IllegalArgumentException.class, () -> CronExpressions.nextExecution("bad", null));
+        assertThrows(IllegalArgumentException.class, () -> CronExpressions.nextExecution("* * * * *", "Not/AZone"));
+    }
+
+    // summaries (UI-facing)
+
+    @Test
+    public void summarizeValidExpression() {
+        CronInfo info = CronExpressions.summarize("0 9 * * 1-5", "Australia/Melbourne");
+
+        assertEquals("0 9 * * 1-5", info.expression);
+        assertTrue(info.valid);
+        assertNull(info.error);
+        assertEquals("at 09:00 every day between Monday and Friday", info.description);
+        assertEquals("Australia/Melbourne", info.timeZone);
+        assertNotNull(info.previous);
+        assertNotNull(info.next);
+        assertTrue(info.next.isAfter(info.previous));
+
+        assertNotNull(info.upcoming);
+        assertEquals(CronInfo.UPCOMING_COUNT, info.upcoming.length);
+        assertEquals(info.next, info.upcoming[0]);
+        for (int i = 1; i < info.upcoming.length; i++)
+            assertTrue(info.upcoming[i].isAfter(info.upcoming[i - 1]));
+    }
+
+    @Test
+    public void summarizeInvalidExpression() {
+        CronInfo info = CronExpressions.summarize("61 * * * *", null);
+
+        assertFalse(info.valid);
+        assertNotNull(info.error);
+        assertNull(info.description);
+        assertNull(info.next);
+        assertNull(info.upcoming);
+    }
+
+    @Test
+    public void summarizeUnknownTimezone() {
+        CronInfo info = CronExpressions.summarize("* * * * *", "Nowhere/Special");
+
+        assertFalse(info.valid);
+        assertTrue(info.error.contains("Nowhere/Special"));
+    }
+
+    @Test
+    public void summarizeDefaultsToHostTimezone() {
+        CronInfo info = CronExpressions.summarize("* * * * *", null);
+
+        assertTrue(info.valid);
+        assertEquals(ZoneId.systemDefault().getId(), info.timeZone);
+    }
+
+    @Test
+    public void summarizeNeverFiringExpression() {
+        CronInfo info = CronExpressions.summarize("0 0 30 2 *", null);
+
+        assertTrue(info.valid);
+        assertNull(info.next);
+        assertNull(info.upcoming);
+    }
+
+    // java.time to JODATIME conversion
+
+    @Test
+    public void toDateTimePreservesInstantAndZone() {
+        ZonedDateTime source = ZonedDateTime.of(2026, 7, 16, 9, 30, 0, 0, MELBOURNE);
+        DateTime converted = CronExpressions.toDateTime(source);
+
+        assertEquals(source.toInstant().toEpochMilli(), converted.getMillis());
+        assertEquals("Australia/Melbourne", converted.getZone().getID());
+        assertNull(CronExpressions.toDateTime(null));
+    }
+
+    @Test
+    public void parseTrimsWhitespace() {
+        Cron cron = CronExpressions.parse("  0 9 * * 1-5  ");
+        assertNotNull(cron);
+    }
+
+}

--- a/nodel-framework/src/test/java/org/nodel/threading/CapturingTimers.java
+++ b/nodel-framework/src/test/java/org/nodel/threading/CapturingTimers.java
@@ -1,0 +1,62 @@
+package org.nodel.threading;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A test-only Timers that records schedule requests instead of arming real
+ * timer threads, letting tests fire tasks deterministically.
+ * (lives in this package for access to 'TimerTask.nativeTimerTask')
+ */
+public class CapturingTimers extends Timers {
+
+    public static class Scheduled {
+
+        public final TimerTask task;
+
+        public final long delay;
+
+        Scheduled(TimerTask task, long delay) {
+            this.task = task;
+            this.delay = delay;
+        }
+
+    }
+
+    public final List<Scheduled> scheduled = new ArrayList<>();
+
+    public CapturingTimers() {
+        // '_' prefix keeps it out of the diagnostics framework
+        super("_capturing");
+    }
+
+    @Override
+    public TimerTask schedule(TimerTask task, long delay) {
+        // a placeholder native task so 'TimerTask.cancel' has something to cancel
+        task.nativeTimerTask = new java.util.TimerTask() {
+
+            @Override
+            public void run() {
+            }
+
+        };
+
+        scheduled.add(new Scheduled(task, delay));
+
+        return task;
+    }
+
+    /**
+     * The most recent schedule request.
+     */
+    public Scheduled last() {
+        return scheduled.isEmpty() ? null : scheduled.get(scheduled.size() - 1);
+    }
+
+}

--- a/nodel-framework/src/test/java/org/nodel/toolkit/ManagedCronTest.java
+++ b/nodel-framework/src/test/java/org/nodel/toolkit/ManagedCronTest.java
@@ -16,8 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.nodel.GitHubIssue;
@@ -55,6 +59,20 @@ public class ManagedCronTest {
 
     };
 
+    /**
+     * Runs callback workers independently so queue-wait lifecycle races can be driven by the test thread.
+     */
+    private final static ThreadPool s_asyncPool = new ThreadPool("_async cron (test)", 1) {
+
+        @Override
+        public void execute(Runnable runnable) {
+            Thread thread = new Thread(runnable, "managed-cron-test-worker");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+    };
+
     private CallbackQueue _callbackQueue;
 
     private AtomicInteger _fires;
@@ -87,9 +105,14 @@ public class ManagedCronTest {
 
         };
 
+        return createCron(callback, expression, timeZone, stopped, s_inlinePool, _callbackQueue);
+    }
+
+    private ManagedCron createCron(H0 callback, String expression, String timeZone, boolean stopped,
+            ThreadPool threadPool, CallbackQueue callbackQueue) {
         H1Sink exceptions = new H1Sink();
 
-        return new ManagedCron(callback, expression, timeZone, stopped, NO_OP, _timers, s_inlinePool, exceptions, _callbackQueue) {
+        return new ManagedCron(callback, expression, timeZone, stopped, NO_OP, _timers, threadPool, exceptions, callbackQueue) {
 
             @Override
             protected long currentTimeMillis() {
@@ -103,6 +126,49 @@ public class ManagedCronTest {
 
         @Override
         public void handle(Exception value) {
+        }
+
+    }
+
+    /**
+     * Stops immediately before entering the real queue, modelling work serialized behind another callback.
+     */
+    private static class BlockingCallbackQueue extends CallbackQueue {
+
+        private CountDownLatch _entered = new CountDownLatch(1);
+
+        private CountDownLatch _release = new CountDownLatch(1);
+
+        private CountDownLatch _completed = new CountDownLatch(1);
+
+        @Override
+        public void handle(H0 callback, org.nodel.Handler.H1<Exception> errorHandler) {
+            _entered.countDown();
+            try {
+                if (!_release.await(5, TimeUnit.SECONDS))
+                    throw new IllegalStateException("Timed out waiting to release the callback queue.");
+
+                super.handle(callback, errorHandler);
+
+            } catch (InterruptedException exc) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(exc);
+
+            } finally {
+                _completed.countDown();
+            }
+        }
+
+        public boolean awaitEntered() throws InterruptedException {
+            return _entered.await(5, TimeUnit.SECONDS);
+        }
+
+        public void release() {
+            _release.countDown();
+        }
+
+        public boolean awaitCompleted() throws InterruptedException {
+            return _completed.await(5, TimeUnit.SECONDS);
         }
 
     }
@@ -178,6 +244,68 @@ public class ManagedCronTest {
         assertEquals(0, _fires.get());
     }
 
+    @Test
+    public void stopSuppressesFireWaitingForCallbackQueue() throws InterruptedException {
+        BlockingCallbackQueue callbackQueue = new BlockingCallbackQueue();
+        ManagedCron cron = createCron(() -> _fires.incrementAndGet(), "* * * * *",
+                "Australia/Melbourne", false, s_asyncPool, callbackQueue);
+        cron.start();
+
+        _nowMillis = cron.getNextExecution().getMillis();
+        _timers.last().task.run();
+        assertTrue(callbackQueue.awaitEntered());
+
+        cron.stop();
+        callbackQueue.release();
+        assertTrue(callbackQueue.awaitCompleted());
+
+        assertEquals(0, _fires.get());
+        assertNull(cron.getLastFired());
+        assertNull(cron.getNextExecution());
+    }
+
+    @Test
+    public void closeSuppressesFireWaitingForCallbackQueue() throws IOException, InterruptedException {
+        BlockingCallbackQueue callbackQueue = new BlockingCallbackQueue();
+        ManagedCron cron = createCron(() -> _fires.incrementAndGet(), "* * * * *",
+                "Australia/Melbourne", false, s_asyncPool, callbackQueue);
+        cron.start();
+
+        _nowMillis = cron.getNextExecution().getMillis();
+        _timers.last().task.run();
+        assertTrue(callbackQueue.awaitEntered());
+
+        cron.close();
+        callbackQueue.release();
+        assertTrue(callbackQueue.awaitCompleted());
+
+        assertEquals(0, _fires.get());
+        assertNull(cron.getLastFired());
+        assertNull(cron.getNextExecution());
+    }
+
+    @Test
+    public void reconfigureSuppressesQueuedFireAndKeepsReplacement() throws InterruptedException {
+        BlockingCallbackQueue callbackQueue = new BlockingCallbackQueue();
+        ManagedCron cron = createCron(() -> _fires.incrementAndGet(), "* * * * *",
+                "Australia/Melbourne", false, s_asyncPool, callbackQueue);
+        cron.start();
+
+        _nowMillis = cron.getNextExecution().getMillis();
+        _timers.last().task.run();
+        assertTrue(callbackQueue.awaitEntered());
+
+        cron.setExpression("0 12 * * *");
+        long replacement = cron.getNextExecution().getMillis();
+        callbackQueue.release();
+        assertTrue(callbackQueue.awaitCompleted());
+
+        assertEquals(0, _fires.get());
+        assertNull(cron.getLastFired());
+        assertEquals(replacement, cron.getNextExecution().getMillis());
+        assertEquals(2, _timers.scheduled.size());
+    }
+
     // firing and rescheduling
 
     @Test
@@ -197,6 +325,80 @@ public class ManagedCronTest {
         assertEquals(millis(following), cron.getNextExecution().getMillis());
         assertEquals(2, _timers.scheduled.size());
         assertEquals(60_000, _timers.last().delay);
+    }
+
+    @Test
+    public void callbackSeesLastFiredAndTheFollowingExecution() {
+        AtomicReference<DateTime> lastDuringCallback = new AtomicReference<>();
+        AtomicReference<DateTime> nextDuringCallback = new AtomicReference<>();
+        ManagedCron[] cronRef = new ManagedCron[1];
+
+        H0 callback = () -> {
+            _fires.incrementAndGet();
+            lastDuringCallback.set(cronRef[0].getLastFired());
+            nextDuringCallback.set(cronRef[0].getNextExecution());
+        };
+
+        cronRef[0] = createCron(callback, "* * * * *", "Australia/Melbourne", false,
+                s_inlinePool, _callbackQueue);
+        cronRef[0].start();
+
+        _nowMillis = millis(ZonedDateTime.of(2026, 7, 16, 10, 1, 0, 0, MELBOURNE));
+        _timers.last().task.run();
+
+        assertEquals(1, _fires.get());
+        assertNotNull(lastDuringCallback.get());
+        assertEquals(_nowMillis, lastDuringCallback.get().getMillis());
+
+        ZonedDateTime following = ZonedDateTime.of(2026, 7, 16, 10, 2, 0, 0, MELBOURNE);
+        assertEquals(millis(following), nextDuringCallback.get().getMillis());
+        assertEquals(lastDuringCallback.get(), cronRef[0].getLastFired());
+    }
+
+    @Test
+    public void selfStopPreservesLastFiredWithoutRearming() {
+        ManagedCron[] cronRef = new ManagedCron[1];
+        H0 callback = () -> {
+            _fires.incrementAndGet();
+            cronRef[0].stop();
+        };
+
+        cronRef[0] = createCron(callback, "* * * * *", "Australia/Melbourne", false,
+                s_inlinePool, _callbackQueue);
+        cronRef[0].start();
+
+        _nowMillis = cronRef[0].getNextExecution().getMillis();
+        _timers.last().task.run();
+
+        assertEquals(1, _fires.get());
+        assertNotNull(cronRef[0].getLastFired());
+        assertEquals(_nowMillis, cronRef[0].getLastFired().getMillis());
+        assertTrue(cronRef[0].isStopped());
+        assertNull(cronRef[0].getNextExecution());
+        assertEquals(1, _timers.scheduled.size());
+    }
+
+    @Test
+    public void selfReconfigurationWinsOverCallbackCompletion() {
+        ManagedCron[] cronRef = new ManagedCron[1];
+        H0 callback = () -> {
+            _fires.incrementAndGet();
+            cronRef[0].setExpression("0 12 * * *");
+        };
+
+        cronRef[0] = createCron(callback, "* * * * *", "Australia/Melbourne", false,
+                s_inlinePool, _callbackQueue);
+        cronRef[0].start();
+
+        _nowMillis = cronRef[0].getNextExecution().getMillis();
+        _timers.last().task.run();
+
+        ZonedDateTime midday = ZonedDateTime.of(2026, 7, 16, 12, 0, 0, 0, MELBOURNE);
+        assertEquals(1, _fires.get());
+        assertNotNull(cronRef[0].getLastFired());
+        assertEquals("0 12 * * *", cronRef[0].getExpression());
+        assertEquals(millis(midday), cronRef[0].getNextExecution().getMillis());
+        assertEquals(2, _timers.scheduled.size());
     }
 
     @Test

--- a/nodel-framework/src/test/java/org/nodel/toolkit/ManagedCronTest.java
+++ b/nodel-framework/src/test/java/org/nodel/toolkit/ManagedCronTest.java
@@ -1,0 +1,417 @@
+package org.nodel.toolkit;
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nodel.GitHubIssue;
+import org.nodel.Handler.H0;
+import org.nodel.threading.CallbackQueue;
+import org.nodel.threading.CapturingTimers;
+import org.nodel.threading.ThreadPool;
+
+/**
+ * Deterministic scheduling tests: time is simulated and the timer layer is captured,
+ * so fires are driven by hand at exact simulated instants.
+ */
+@GitHubIssue("https://github.com/museumsvictoria/nodel/issues/411")
+public class ManagedCronTest {
+
+    private final static ZoneId MELBOURNE = ZoneId.of("Australia/Melbourne");
+
+    /**
+     * A fixed reference point: Thursday 2026-07-16 10:00:30 (Melbourne).
+     */
+    private final static ZonedDateTime T0 = ZonedDateTime.of(2026, 7, 16, 10, 0, 30, 0, MELBOURNE);
+
+    private CapturingTimers _timers;
+
+    /**
+     * Executes inline so tests stay single-threaded and deterministic.
+     * (one static instance: ThreadPool registers a uniquely-named diagnostics counter)
+     */
+    private final static ThreadPool s_inlinePool = new ThreadPool("_inline (test)", 1) {
+
+        @Override
+        public void execute(Runnable runnable) {
+            runnable.run();
+        }
+
+    };
+
+    private CallbackQueue _callbackQueue;
+
+    private AtomicInteger _fires;
+
+    private long _nowMillis;
+
+    private final static H0 NO_OP = new H0() {
+
+        @Override
+        public void handle() {
+        }
+
+    };
+
+    @BeforeEach
+    public void setup() {
+        _timers = new CapturingTimers();
+        _callbackQueue = new CallbackQueue();
+        _fires = new AtomicInteger();
+        _nowMillis = T0.toInstant().toEpochMilli();
+    }
+
+    private ManagedCron createCron(String expression, String timeZone, boolean stopped) {
+        H0 callback = new H0() {
+
+            @Override
+            public void handle() {
+                _fires.incrementAndGet();
+            }
+
+        };
+
+        H1Sink exceptions = new H1Sink();
+
+        return new ManagedCron(callback, expression, timeZone, stopped, NO_OP, _timers, s_inlinePool, exceptions, _callbackQueue) {
+
+            @Override
+            protected long currentTimeMillis() {
+                return _nowMillis;
+            }
+
+        };
+    }
+
+    private static class H1Sink implements org.nodel.Handler.H1<Exception> {
+
+        @Override
+        public void handle(Exception value) {
+        }
+
+    }
+
+    private static long millis(ZonedDateTime value) {
+        return value.toInstant().toEpochMilli();
+    }
+
+    // construction and validation
+
+    @Test
+    public void rejectsInvalidExpressionAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> createCron("61 * * * *", null, false));
+        assertThrows(IllegalArgumentException.class, () -> createCron("* * * *", null, false));
+    }
+
+    @Test
+    public void rejectsUnknownTimezoneAtConstruction() {
+        assertThrows(IllegalArgumentException.class, () -> createCron("* * * * *", "Not/AZone", false));
+    }
+
+    // start / stop lifecycle
+
+    @Test
+    public void startSchedulesTheNextMinuteBoundary() {
+        ManagedCron cron = createCron("* * * * *", "Australia/Melbourne", false);
+        assertTrue(cron.isStopped());
+        assertNull(cron.getNextExecution());
+
+        cron.start();
+
+        assertTrue(cron.isStarted());
+
+        // T0 is hh:00:30, so the next occurrence is hh:01:00 — 30 s away
+        ZonedDateTime expected = ZonedDateTime.of(2026, 7, 16, 10, 1, 0, 0, MELBOURNE);
+        assertEquals(millis(expected), cron.getNextExecution().getMillis());
+        assertEquals(1, _timers.scheduled.size());
+        assertEquals(30_000, _timers.last().delay);
+    }
+
+    @Test
+    public void startIsIdempotent() {
+        ManagedCron cron = createCron("* * * * *", null, false);
+        cron.start();
+        cron.start();
+
+        assertEquals(1, _timers.scheduled.size());
+    }
+
+    @Test
+    public void stopClearsThePendingFire() {
+        ManagedCron cron = createCron("* * * * *", null, false);
+        cron.start();
+        cron.stop();
+
+        assertTrue(cron.isStopped());
+        assertNull(cron.getNextExecution());
+        assertTrue(_timers.last().task.isCancelled());
+    }
+
+    @Test
+    public void stoppedTaskDoesNotFire() {
+        ManagedCron cron = createCron("* * * * *", null, false);
+        cron.start();
+
+        CapturingTimers.Scheduled pending = _timers.last();
+        cron.stop();
+
+        // even if the timer layer still delivers it
+        _nowMillis += 30_000;
+        pending.task.run();
+
+        assertEquals(0, _fires.get());
+    }
+
+    // firing and rescheduling
+
+    @Test
+    public void firesOnTimeAndReschedules() {
+        ManagedCron cron = createCron("* * * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        // deliver exactly on target
+        _nowMillis = millis(ZonedDateTime.of(2026, 7, 16, 10, 1, 0, 0, MELBOURNE));
+        _timers.last().task.run();
+
+        assertEquals(1, _fires.get());
+        assertNotNull(cron.getLastFired());
+
+        // rescheduled for the following minute
+        ZonedDateTime following = ZonedDateTime.of(2026, 7, 16, 10, 2, 0, 0, MELBOURNE);
+        assertEquals(millis(following), cron.getNextExecution().getMillis());
+        assertEquals(2, _timers.scheduled.size());
+        assertEquals(60_000, _timers.last().delay);
+    }
+
+    @Test
+    public void delayedFireCoalescesToASingleInvocation() {
+        // a fire that arrives late — e.g. the host was suspended — happens once,
+        // and the occurrences missed in between are never replayed
+        ManagedCron cron = createCron("* * * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        // deliver 5 minutes late
+        _nowMillis = millis(ZonedDateTime.of(2026, 7, 16, 10, 6, 0, 0, MELBOURNE));
+        _timers.last().task.run();
+
+        assertEquals(1, _fires.get());
+
+        // next fire looks forward from 'now' — 10:01 through 10:06 are gone
+        ZonedDateTime lookedForward = ZonedDateTime.of(2026, 7, 16, 10, 7, 0, 0, MELBOURNE);
+        assertEquals(millis(lookedForward), cron.getNextExecution().getMillis());
+    }
+
+    @Test
+    public void earlyWakeSleepsOutTheRemainderWithoutFiring() {
+        // guards against wall-clock adjustments waking the timer layer prematurely
+        ManagedCron cron = createCron("* * * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        CapturingTimers.Scheduled pending = _timers.last();
+
+        // deliver 10 s early
+        _nowMillis += 20_000;
+        pending.task.run();
+
+        assertEquals(0, _fires.get());
+        assertEquals(2, _timers.scheduled.size());
+        assertEquals(10_000, _timers.last().delay);
+
+        // the remainder then fires normally
+        _nowMillis += 10_000;
+        _timers.last().task.run();
+        assertEquals(1, _fires.get());
+    }
+
+    @Test
+    public void freshInstanceBeginsAtTheNextFutureOccurrence() {
+        // restart policy: state is never persisted, so a schedule re-created after a
+        // host restart looks forward only — no replay of occurrences missed while down
+        ManagedCron cron = createCron("0 9 * * MON-FRI", "Australia/Melbourne", false);
+        cron.start();
+
+        // T0 is Thursday 10:00:30, after today's 09:00 — first target is Friday 09:00
+        ZonedDateTime friday9am = ZonedDateTime.of(2026, 7, 17, 9, 0, 0, 0, MELBOURNE);
+        assertEquals(millis(friday9am), cron.getNextExecution().getMillis());
+        assertEquals(0, _fires.get());
+    }
+
+    // reconfiguration
+
+    @Test
+    public void setExpressionReschedulesInPlace() {
+        ManagedCron cron = createCron("* * * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        cron.setExpression("0 12 * * *");
+
+        assertEquals("0 12 * * *", cron.getExpression());
+        ZonedDateTime midday = ZonedDateTime.of(2026, 7, 16, 12, 0, 0, 0, MELBOURNE);
+        assertEquals(millis(midday), cron.getNextExecution().getMillis());
+
+        // the superseded task can no longer fire
+        assertTrue(_timers.scheduled.get(0).task.isCancelled());
+        _timers.scheduled.get(0).task.run();
+        assertEquals(0, _fires.get());
+    }
+
+    @Test
+    public void invalidReconfigurationLeavesScheduleInPlace() {
+        ManagedCron cron = createCron("* * * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        long before = cron.getNextExecution().getMillis();
+
+        assertThrows(IllegalArgumentException.class, () -> cron.setExpression("nope"));
+        assertThrows(IllegalArgumentException.class, () -> cron.setTimeZone("Not/AZone"));
+
+        assertEquals("* * * * *", cron.getExpression());
+        assertEquals("Australia/Melbourne", cron.getTimeZone());
+        assertEquals(before, cron.getNextExecution().getMillis());
+        assertFalse(_timers.last().task.isCancelled());
+    }
+
+    @Test
+    public void setTimeZoneReschedules() {
+        ManagedCron cron = createCron("0 12 * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        cron.setTimeZone("Pacific/Auckland");
+
+        assertEquals("Pacific/Auckland", cron.getTimeZone());
+        // T0 (10:00:30 Melbourne) is 12:00:30 in Auckland — its midday has just passed
+        ZonedDateTime aucklandMidday = ZonedDateTime.of(2026, 7, 17, 12, 0, 0, 0, ZoneId.of("Pacific/Auckland"));
+        assertEquals(millis(aucklandMidday), cron.getNextExecution().getMillis());
+    }
+
+    @Test
+    public void reconfigureWhileStoppedStaysStopped() {
+        ManagedCron cron = createCron("* * * * *", null, false);
+
+        cron.setExpression("0 12 * * *");
+
+        assertTrue(cron.isStopped());
+        assertNull(cron.getNextExecution());
+        assertEquals(0, _timers.scheduled.size());
+    }
+
+    // introspection
+
+    @Test
+    public void exposesDescriptionAndPreviousExecution() {
+        ManagedCron cron = createCron("0 9 * * 1-5", "Australia/Melbourne", false);
+
+        assertEquals("at 09:00 every day between Monday and Friday", cron.getDescription());
+
+        // previous occurrence before Thursday 10:00:30 is Thursday 09:00
+        ZonedDateTime thursday9am = ZonedDateTime.of(2026, 7, 16, 9, 0, 0, 0, MELBOURNE);
+        assertEquals(millis(thursday9am), cron.getPreviousExecution().getMillis());
+
+        assertNull(cron.getLastFired());
+    }
+
+    @Test
+    public void defaultTimezoneIsTheHostZone() {
+        ManagedCron cron = createCron("* * * * *", null, false);
+        assertEquals(ZoneId.systemDefault().getId(), cron.getTimeZone());
+    }
+
+    @Test
+    public void neverFiringExpressionStaysDormant() {
+        ManagedCron cron = createCron("0 0 30 2 *", null, false);
+        cron.start();
+
+        assertTrue(cron.isStarted());
+        assertNull(cron.getNextExecution());
+        assertEquals(0, _timers.scheduled.size());
+    }
+
+    @Test
+    public void carriesTheStoppedAtFirstFlag() {
+        assertTrue(createCron("* * * * *", null, true).getStoppedAtFirst());
+        assertFalse(createCron("* * * * *", null, false).getStoppedAtFirst());
+    }
+
+    // shutdown
+
+    @Test
+    public void closePreventsFurtherUse() throws IOException {
+        ManagedCron cron = createCron("* * * * *", null, false);
+        cron.start();
+
+        CapturingTimers.Scheduled pending = _timers.last();
+        cron.close();
+
+        assertTrue(cron.isStopped());
+        assertNull(cron.getNextExecution());
+
+        // a late delivery after shutdown is ignored
+        _nowMillis += 60_000;
+        pending.task.run();
+        assertEquals(0, _fires.get());
+
+        // and it cannot be restarted
+        cron.start();
+        assertTrue(cron.isStopped());
+        assertEquals(1, _timers.scheduled.size());
+    }
+
+    @Test
+    public void closeBeforeStartIsSafe() throws IOException {
+        ManagedCron cron = createCron("* * * * *", null, true);
+        cron.close();
+
+        assertTrue(cron.isStopped());
+    }
+
+    // daylight-saving behaviour through the managed layer
+
+    @Test
+    public void dstGapOccurrenceIsSkipped() {
+        // Melbourne spring-forward 2026-10-04: 02:30 does not exist that day
+        _nowMillis = millis(ZonedDateTime.of(2026, 10, 3, 12, 0, 0, 0, MELBOURNE));
+
+        ManagedCron cron = createCron("30 2 * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        ZonedDateTime afterGap = ZonedDateTime.of(2026, 10, 5, 2, 30, 0, 0, MELBOURNE);
+        assertEquals(millis(afterGap), cron.getNextExecution().getMillis());
+    }
+
+    @Test
+    public void dstOverlapOccurrenceFiresOnce() {
+        // Melbourne fall-back 2026-04-05: wall-clock 02:30 happens twice; one fire results
+        _nowMillis = millis(ZonedDateTime.of(2026, 4, 4, 12, 0, 0, 0, MELBOURNE));
+
+        ManagedCron cron = createCron("30 2 * * *", "Australia/Melbourne", false);
+        cron.start();
+
+        ZonedDateTime firstPass = ZonedDateTime.of(2026, 4, 5, 2, 30, 0, 0, MELBOURNE).withEarlierOffsetAtOverlap();
+        assertEquals(millis(firstPass), cron.getNextExecution().getMillis());
+
+        // fire it: the next target is the day after — the repeated wall-clock 02:30 is not revisited
+        _nowMillis = millis(firstPass);
+        _timers.last().task.run();
+
+        assertEquals(1, _fires.get());
+        ZonedDateTime nextDay = ZonedDateTime.of(2026, 4, 6, 2, 30, 0, 0, MELBOURNE);
+        assertEquals(millis(nextDay), cron.getNextExecution().getMillis());
+    }
+
+}

--- a/nodel-jyhost/src/main/resources/org/nodel/jyhost/nodetoolkit.py
+++ b/nodel-jyhost/src/main/resources/org/nodel/jyhost/nodetoolkit.py
@@ -198,6 +198,77 @@ class Timer:
   def isStopped(self):
       return self.wrapper.isStopped()
 
+# A managed CRON schedule using standard five-field UNIX expressions
+# ('<minute> <hour> <day-of-month> <month> <day-of-week>', names like MON or JAN allowed,
+#  Sunday as 0 or 7; the host timezone applies unless an IANA 'timezone' is given)
+# e.g. Cron(lambda: console.info('school run!'), '30 8 * * MON-FRI')
+# (raises an exception immediately when the expression or timezone is invalid)
+class Cron:
+  def __init__(self, func, expression, timezone=None, stopped=False):
+      self.wrapper = nodetoolkit.createCron(func, expression, timezone, stopped)
+
+  def setExpression(self, expression):
+      self.wrapper.setExpression(expression)
+
+  def getExpression(self):
+      return self.wrapper.getExpression()
+
+  def setTimezone(self, timezone):
+      self.wrapper.setTimeZone(timezone)
+
+  def getTimezone(self):
+      return self.wrapper.getTimeZone()
+
+  # a human-readable description e.g. 'at 09:00 every day between Monday and Friday'
+  def getDescription(self):
+      return self.wrapper.getDescription()
+
+  # when this schedule will next fire (None when stopped or when it can never fire)
+  def getNextExecution(self):
+      return self.wrapper.getNextExecution()
+
+  # the most recent occurrence of the expression before now (None if none)
+  def getPreviousExecution(self):
+      return self.wrapper.getPreviousExecution()
+
+  # when the callback actually last fired (None if never)
+  def getLastFired(self):
+      return self.wrapper.getLastFired()
+
+  def start(self):
+      self.wrapper.start()
+
+  def stop(self):
+      self.wrapper.stop()
+
+  def isStarted(self):
+      return self.wrapper.isStarted()
+
+  def isStopped(self):
+      return self.wrapper.isStopped()
+
+# Returns None when a CRON expression is valid, otherwise the failure reason
+def cron_validate(expression):
+    return nodetoolkit.cronValidate(expression)
+
+# Whether a CRON expression parses and validates
+def cron_is_valid(expression):
+    return nodetoolkit.cronIsValid(expression)
+
+# A human-readable description of a CRON expression (raises when invalid)
+def cron_describe(expression):
+    return nodetoolkit.cronDescribe(expression)
+
+# The next execution of a CRON expression after now as a DateTime, or None if it can never fire
+# (optional IANA timezone; raises when the expression or timezone is invalid)
+def cron_next(expression, timezone=None):
+    return nodetoolkit.cronNextExecution(expression, timezone)
+
+# The most recent execution of a CRON expression before now as a DateTime, or None
+# (optional IANA timezone; raises when the expression or timezone is invalid)
+def cron_previous(expression, timezone=None):
+    return nodetoolkit.cronPreviousExecution(expression, timezone)
+
 # Create a node (on-the-fly)
 def Node(nodeName):
     return nodetoolkit.createNode(nodeName)

--- a/nodel-jyhost/src/test/java/org/nodel/CronEditorE2ETests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/CronEditorE2ETests.java
@@ -1,0 +1,159 @@
+package org.nodel;
+
+import com.microsoft.playwright.APIResponse;
+import com.microsoft.playwright.Locator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Real-browser coverage for the restored 'format: "cron"' editor (issues #411 / #196):
+ * a parameter declared with the cron format renders as a text input with live,
+ * host-backed validation and schedule feedback — both in the technical node UI and
+ * on a custom dashboard (the shared path Frontend/Mk2-style nodes consume).
+ */
+@Tag("e2e")
+public class CronEditorE2ETests extends TestBase {
+
+    private static final String TECH_NODE = "Cron Editor Test";
+
+    private static final String DASH_NODE = "Cron Dashboard Test";
+
+    /**
+     * (the schema shape the retired scheduler recipes used)
+     */
+    private static final String CRON_PARAM_SCRIPT =
+        "param_schedule = Parameter({'title': 'Schedule', 'schema': {'type': 'string', 'format': 'cron',\n" +
+        "    'title': 'Cron', 'desc': 'Format: <minute> <hour> <day> <month> <day of week>'}})\n" +
+        "\n" +
+        "def main():\n" +
+        "    console.info('Cron editor test started')\n";
+
+    /**
+     * A minimal Frontend/Mk2-style dashboard: node-local content that pulls the shared
+     * v1 assets and embeds the schema-driven parameters form.
+     */
+    private static final String DASHBOARD_XML =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<?xml-stylesheet type=\"text/xsl\" href=\"v1/index.xsl\"?>\n" +
+        "<pages title='Cron Dashboard Test' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='v1/index.xsd'>\n" +
+        "  <page title='Setup'>\n" +
+        "    <row>\n" +
+        "      <column sm='6'>\n" +
+        "        <title>Parameters</title>\n" +
+        "        <nodel type='params'/>\n" +
+        "      </column>\n" +
+        "    </row>\n" +
+        "  </page>\n" +
+        "</pages>\n";
+
+    @BeforeAll
+    public static void setup() {
+        initBrowser();
+
+        assumeTrue(createTestNode(TECH_NODE, CRON_PARAM_SCRIPT), "technical-UI test node must initialise");
+        assumeTrue(createTestNode(DASH_NODE, CRON_PARAM_SCRIPT), "dashboard test node must initialise");
+
+        APIResponse response = uploadNodeFile(DASH_NODE, "content/index.xml", DASHBOARD_XML);
+        assertEquals(200, response.status(), "content/index.xml upload should return 200");
+    }
+
+    @AfterAll
+    public static void teardown() {
+        deleteTestNode(TECH_NODE);
+        deleteTestNode(DASH_NODE);
+        closeBrowser();
+    }
+
+    @Test
+    public void testCronEditorInTechnicalUi() {
+        recreatePage();
+        navigateToNode(TECH_NODE);
+
+        // the parameters form lives on the 'Config' page. The page-switch handler is
+        // wired only once node data has loaded, so keep clicking until it takes effect.
+        Locator configNav = page.locator("[data-nav=Config]").first();
+        String failure = pollUntil(() -> {
+            configNav.click();
+            return page.locator("input.nodel-cron").first().isVisible();
+        }, 30000, 500, "the 'Config' page to present the cron editor");
+        assertTrue(failure == null, String.valueOf(failure));
+
+        exerciseCronEditor();
+    }
+
+    @Test
+    public void testSavedExpressionFeedbackShowsOnLoad() {
+        // a saved expression must show its feedback (or its error) as soon as the form
+        // is populated, without waiting for the user to touch the field
+        APIResponse save = apiPost("/nodes/" + encode(TECH_NODE) + "/params/save",
+                "{\"schedule\":\"0 17 * * FRI\"}");
+        assertEquals(200, save.status(), "params/save should be accepted");
+
+        recreatePage();
+        navigateToNode(TECH_NODE);
+
+        Locator configNav = page.locator("[data-nav=Config]").first();
+        String failure = pollUntil(() -> {
+            configNav.click();
+            return page.locator("input.nodel-cron").first().isVisible();
+        }, 30000, 500, "the 'Config' page to present the cron editor");
+        assertTrue(failure == null, String.valueOf(failure));
+
+        Locator feedback = page.locator(".nodel-cron-feedback").first();
+        failure = pollUntil(() -> feedback.textContent().contains("at 17:00 at Friday day"),
+                10000, 250, "load-time feedback for the saved expression");
+        assertTrue(failure == null, String.valueOf(failure));
+    }
+
+    @Test
+    public void testCronEditorOnCustomDashboard() {
+        // the Frontend/Mk2-style path: node-local index.xml rendered through the shared
+        // v1 pipeline; the same editor and host-backed feedback with no per-node code
+        recreatePage();
+        navigateToNode(DASH_NODE);
+
+        exerciseCronEditor();
+    }
+
+    /**
+     * Types valid and invalid expressions and asserts the live feedback both ways.
+     */
+    private void exerciseCronEditor() {
+        waitForElement("input.nodel-cron");
+        Locator input = page.locator("input.nodel-cron").first();
+        Locator group = input.locator("xpath=ancestor::div[contains(@class,'form-group')][1]");
+        Locator feedback = group.locator(".nodel-cron-feedback").first();
+
+        // a valid expression shows the description and the next execution
+        input.fill("0 9 * * 1-5");
+        String failure = pollUntil(
+                () -> feedback.textContent().contains("at 09:00 every day between Monday and Friday"),
+                10000, 250, "valid-expression feedback");
+        assertTrue(failure == null, String.valueOf(failure));
+        assertTrue(feedback.textContent().contains("next:"), "the next execution should be shown");
+        assertTrue(!group.getAttribute("class").contains("has-error"), "no error styling for a valid expression");
+
+        // an invalid expression shows the reason with error styling
+        input.fill("61 * * * *");
+        failure = pollUntil(
+                () -> feedback.textContent().contains("not in range")
+                        && group.getAttribute("class").contains("has-error"),
+                10000, 250, "invalid-expression feedback");
+        assertTrue(failure == null, String.valueOf(failure));
+
+        // clearing the field clears the feedback
+        input.fill("");
+        failure = pollUntil(
+                () -> feedback.textContent().trim().isEmpty()
+                        && !group.getAttribute("class").contains("has-error"),
+                10000, 250, "feedback to clear");
+        assertTrue(failure == null, String.valueOf(failure));
+    }
+
+}

--- a/nodel-jyhost/src/test/java/org/nodel/CronSupportTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/CronSupportTests.java
@@ -1,0 +1,224 @@
+package org.nodel;
+
+import com.microsoft.playwright.APIResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration coverage for the managed CRON scheduling support (issue #411):
+ * the Jython toolkit API ('Cron' class and 'cron_*' helpers), the per-node
+ * 'REST/cron' endpoint, live scheduling through the shared timer infrastructure,
+ * and schedule re-registration across a node restart.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CronSupportTests extends TestBase {
+
+    private static final String TOOLKIT_NODE = "Cron Toolkit Test";
+
+    private static final String FIRE_NODE = "Cron Fire Test";
+
+    /**
+     * Logs one line per toolkit surface so each can be asserted independently.
+     */
+    private static final String TOOLKIT_SCRIPT =
+        "held = Cron(lambda: console.info('held cron fired'), '30 8 * * MON-FRI', timezone='Australia/Melbourne', stopped=True)\n" +
+        "\n" +
+        "def main():\n" +
+        "    console.info('Cron toolkit test started')\n" +
+        "    console.info('is-valid: %s' % cron_is_valid('30 8 * * MON-FRI'))\n" +
+        "    console.info('validate-ok-is-none: %s' % (cron_validate('*/5 * * * *') is None))\n" +
+        "    console.info('validate-bad: %s' % cron_validate('61 * * * *'))\n" +
+        "    console.info('describe: %s' % cron_describe('30 8 * * MON-FRI'))\n" +
+        "    console.info('next-in-future: %s' % (cron_next('* * * * *').isAfterNow()))\n" +
+        "    console.info('previous-in-past: %s' % (cron_previous('* * * * *').isBeforeNow()))\n" +
+        "    console.info('held-description: %s' % held.getDescription())\n" +
+        "    console.info('held-timezone: %s' % held.getTimezone())\n" +
+        "    console.info('held-stopped: %s' % held.isStopped())\n" +
+        "    held.start()\n" +
+        "    console.info('held-started: %s' % held.isStarted())\n" +
+        "    console.info('held-next-is-set: %s' % (held.getNextExecution() is not None))\n" +
+        "    held.setExpression('0 22 * * SUN')\n" +
+        "    console.info('held-reconfigured: %s' % held.getExpression())\n" +
+        "    try:\n" +
+        "        held.setExpression('not a cron')\n" +
+        "        console.info('held-bad-reconfigure: accepted')\n" +
+        "    except:\n" +
+        "        console.info('held-bad-reconfigure: rejected, kept %s' % held.getExpression())\n" +
+        "    try:\n" +
+        "        Cron(lambda: None, '61 * * * *')\n" +
+        "        console.info('bad-expression: accepted')\n" +
+        "    except:\n" +
+        "        console.info('bad-expression: rejected')\n";
+
+    /**
+     * An every-minute schedule proves a real fire end-to-end (worst case ~60 s wait).
+     */
+    private static final String FIRE_SCRIPT =
+        "cron = Cron(lambda: console.info('CRON-FIRED next=%s' % cron.getNextExecution()), '* * * * *')\n" +
+        "\n" +
+        "def main():\n" +
+        "    console.info('Cron fire test started')\n";
+
+    @BeforeAll
+    public static void setup() {
+        initBrowser();
+        assertTrue(createTestNode(TOOLKIT_NODE, TOOLKIT_SCRIPT), "toolkit test node should initialise");
+        assertTrue(createTestNode(FIRE_NODE, FIRE_SCRIPT), "fire test node should initialise");
+    }
+
+    @AfterAll
+    public static void teardown() {
+        deleteTestNode(TOOLKIT_NODE);
+        deleteTestNode(FIRE_NODE);
+        closeBrowser();
+    }
+
+    // Jython toolkit API
+
+    @Test
+    @Order(1)
+    public void testCronHelpersFromRecipe() {
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "is-valid: True", 10000),
+                "cron_is_valid should accept a five-field expression");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "validate-ok-is-none: True", 10000),
+                "cron_validate should return None for a valid expression");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "validate-bad: Invalid CRON expression", 10000),
+                "cron_validate should return the failure reason");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "describe: at 08:30 every day between Monday and Friday", 10000),
+                "cron_describe should produce a human-readable description");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "next-in-future: True", 10000),
+                "cron_next should be in the future");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "previous-in-past: True", 10000),
+                "cron_previous should be in the past");
+    }
+
+    @Test
+    @Order(2)
+    public void testCronClassLifecycleFromRecipe() {
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-description: at 08:30 every day between Monday and Friday", 10000),
+                "Cron.getDescription should describe the schedule");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-timezone: Australia/Melbourne", 10000),
+                "Cron.getTimezone should reflect the configured IANA timezone");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-stopped: True", 10000),
+                "stopped=True should hold the schedule");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-started: True", 10000),
+                "Cron.start should start a held schedule");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-next-is-set: True", 10000),
+                "a started schedule should expose its next execution");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-reconfigured: 0 22 * * SUN", 10000),
+                "Cron.setExpression should reconfigure in place");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "held-bad-reconfigure: rejected, kept 0 22 * * SUN", 10000),
+                "an invalid reconfiguration should raise and keep the previous expression");
+        assertTrue(waitForConsoleContains(TOOLKIT_NODE, "bad-expression: rejected", 10000),
+                "constructing with an invalid expression should raise immediately");
+    }
+
+    // per-node REST endpoint (used by the web UI and custom dashboards)
+
+    @Test
+    @Order(3)
+    public void testCronRestEndpointValid() {
+        APIResponse response = apiGet("/nodes/" + encode(TOOLKIT_NODE)
+                + "/cron?expression=" + encode("0 9 * * 1-5") + "&timezone=Australia/Melbourne");
+        assertEquals(200, response.status(), "REST/cron should respond");
+
+        String body = response.text().replace(" ", "");
+        assertTrue(body.contains("\"valid\":true"), "expression should validate: " + response.text());
+        assertTrue(response.text().contains("at 09:00 every day between Monday and Friday"),
+                "a description should be included: " + response.text());
+        assertTrue(body.contains("\"timeZone\":\"Australia/Melbourne\""),
+                "the effective timezone should be echoed: " + response.text());
+        assertTrue(body.contains("\"next\":"), "the next execution should be included: " + response.text());
+        assertTrue(body.contains("\"previous\":"), "the previous execution should be included: " + response.text());
+        assertTrue(body.contains("\"upcoming\":"), "upcoming executions should be included: " + response.text());
+    }
+
+    @Test
+    @Order(4)
+    public void testCronRestEndpointInvalid() {
+        APIResponse response = apiGet("/nodes/" + encode(TOOLKIT_NODE)
+                + "/cron?expression=" + encode("61 * * * *"));
+        assertEquals(200, response.status(), "REST/cron should respond even for invalid input");
+
+        String body = response.text().replace(" ", "");
+        assertTrue(body.contains("\"valid\":false"), "expression should be rejected: " + response.text());
+        assertTrue(body.contains("\"error\":"), "the failure reason should be included: " + response.text());
+    }
+
+    @Test
+    @Order(5)
+    public void testCronRestEndpointSundayForms() {
+        // Sunday as 0, 7 or a name resolves to the same schedule
+        String nextFor0 = null;
+        for (String dow : new String[] { "0", "7", "SUN" }) {
+            APIResponse response = apiGet("/nodes/" + encode(TOOLKIT_NODE)
+                    + "/cron?expression=" + encode("0 22 * * " + dow) + "&timezone=Australia/Melbourne");
+            assertEquals(200, response.status());
+            String body = response.text().replace(" ", "");
+            assertTrue(body.contains("\"valid\":true"), "Sunday as '" + dow + "' should validate");
+
+            String next = body.replaceAll(".*\"next\":\"([^\"]+)\".*", "$1");
+            if (nextFor0 == null)
+                nextFor0 = next;
+            else
+                assertEquals(nextFor0, next, "Sunday as '" + dow + "' should schedule identically");
+        }
+    }
+
+    // live scheduling through the shared timer infrastructure
+
+    @Test
+    @Order(6)
+    public void testCronFiresOnTheMinute() {
+        // an every-minute schedule must fire within ~60 s (plus margin for a busy host)
+        assertTrue(waitForConsoleContains(FIRE_NODE, "CRON-FIRED", 75000),
+                "a started '* * * * *' schedule should fire at the next minute boundary");
+    }
+
+    @Test
+    @Order(7)
+    public void testCronSurvivesNodeRestart() {
+        // restarting the node tears the toolkit down and re-runs the recipe: the schedule
+        // must be re-registered and look forward only. The console survives a script
+        // restart, so count fires rather than just checking presence.
+        int firesBeforeRestart = countInConsole(FIRE_NODE, "CRON-FIRED");
+        int startsBeforeRestart = countInConsole(FIRE_NODE, "Cron fire test started");
+
+        APIResponse restart = apiPost("/nodes/" + encode(FIRE_NODE) + "/restart");
+        assertEquals(200, restart.status(), "node restart should be accepted");
+
+        assertTrue(waitForNodeResponsive(FIRE_NODE, 30000), "node should come back after restart");
+
+        String rerun = pollUntil(() -> countInConsole(FIRE_NODE, "Cron fire test started") > startsBeforeRestart,
+                30000, 500, "the recipe to re-run after restart");
+        assertTrue(rerun == null, String.valueOf(rerun));
+
+        String refire = pollUntil(() -> countInConsole(FIRE_NODE, "CRON-FIRED") > firesBeforeRestart,
+                75000, 500, "the re-registered schedule to fire after restart");
+        assertTrue(refire == null, String.valueOf(refire));
+    }
+
+    /**
+     * Occurrences of a substring across the node's recent console output.
+     */
+    private static int countInConsole(String nodeName, String text) {
+        APIResponse response = apiGet("/nodes/" + encode(nodeName) + "/console?from=0&max=1000");
+        if (response.status() != 200)
+            return 0;
+
+        String body = response.text();
+        int count = 0;
+        for (int at = body.indexOf(text); at >= 0; at = body.indexOf(text, at + text.length()))
+            count++;
+
+        return count;
+    }
+
+}

--- a/nodel-jyhost/src/test/java/org/nodel/CronSupportTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/CronSupportTests.java
@@ -1,5 +1,7 @@
 package org.nodel;
 
+import java.util.Collections;
+
 import com.microsoft.playwright.APIResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +63,8 @@ public class CronSupportTests extends TestBase {
      * An every-minute schedule proves a real fire end-to-end (worst case ~60 s wait).
      */
     private static final String FIRE_SCRIPT =
-        "cron = Cron(lambda: console.info('CRON-FIRED next=%s' % cron.getNextExecution()), '* * * * *')\n" +
+        "cron = Cron(lambda: console.info('CRON-FIRED last-set=%s next-future=%s' % " +
+        "(cron.getLastFired() is not None, cron.getNextExecution().isAfterNow())), '* * * * *')\n" +
         "\n" +
         "def main():\n" +
         "    console.info('Cron fire test started')\n";
@@ -154,6 +157,22 @@ public class CronSupportTests extends TestBase {
 
     @Test
     @Order(5)
+    public void testCronRestEndpointBoundsOversizedInput() {
+        String expression = String.join(",", Collections.nCopies(253, "0")) + " * * * *";
+        APIResponse response = apiPost("/nodes/" + encode(TOOLKIT_NODE) + "/cron",
+                "{\"expression\":\"" + expression + "\"}");
+        assertEquals(200, response.status(), "REST/cron should return its diagnostic contract");
+
+        String responseText = response.text();
+        String body = responseText.replace(" ", "");
+        assertTrue(body.contains("\"valid\":false"), "oversized expression should be rejected: " + responseText);
+        assertTrue(responseText.contains("maximum 512"), "the bounded failure reason should be included: " + responseText);
+        assertTrue(responseText.length() < 2048, "the diagnostic response should remain bounded");
+        assertTrue(!responseText.contains(expression), "the oversized expression should not be echoed");
+    }
+
+    @Test
+    @Order(6)
     public void testCronRestEndpointSundayForms() {
         // Sunday as 0, 7 or a name resolves to the same schedule
         String nextFor0 = null;
@@ -175,15 +194,15 @@ public class CronSupportTests extends TestBase {
     // live scheduling through the shared timer infrastructure
 
     @Test
-    @Order(6)
+    @Order(7)
     public void testCronFiresOnTheMinute() {
         // an every-minute schedule must fire within ~60 s (plus margin for a busy host)
-        assertTrue(waitForConsoleContains(FIRE_NODE, "CRON-FIRED", 75000),
-                "a started '* * * * *' schedule should fire at the next minute boundary");
+        assertTrue(waitForConsoleContains(FIRE_NODE, "CRON-FIRED last-set=True next-future=True", 75000),
+                "the callback should see its last fire and following execution at the next minute boundary");
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     public void testCronSurvivesNodeRestart() {
         // restarting the node tears the toolkit down and re-runs the recipe: the schedule
         // must be re-registered and look forward only. The console survives a script

--- a/nodel-jyhost/src/test/java/org/nodel/FrontendSpacingRegressionTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/FrontendSpacingRegressionTests.java
@@ -1,7 +1,6 @@
 package org.nodel;
 
 import com.microsoft.playwright.APIResponse;
-import com.microsoft.playwright.options.RequestOptions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -61,11 +60,7 @@ public class FrontendSpacingRegressionTests extends TestBase {
         boolean created = createTestNode(TEST_NODE, TEST_SCRIPT);
         assumeTrue(created, "Test node must be created and discovered for spacing regression tests");
 
-        APIResponse response = page.request().post(
-            REST_BASE + "/nodes/" + encode(TEST_NODE) + "/files/save?path=content/index.xml",
-            RequestOptions.create()
-                .setHeader("Content-Type", "application/octet-stream")
-                .setData(INDEX_XML));
+        APIResponse response = uploadNodeFile(TEST_NODE, "content/index.xml", INDEX_XML);
 
         assertEquals(200, response.status(), "content/index.xml upload should return 200");
     }

--- a/nodel-jyhost/src/test/java/org/nodel/TestBase.java
+++ b/nodel-jyhost/src/test/java/org/nodel/TestBase.java
@@ -231,6 +231,18 @@ public abstract class TestBase {
     }
 
     /**
+     * Upload a file into a node's directory via the 'files/save' endpoint
+     * (e.g. a custom 'content/index.xml' dashboard).
+     */
+    protected static APIResponse uploadNodeFile(String nodeName, String path, String content) {
+        return page.request().post(
+            REST_BASE + "/nodes/" + encode(nodeName) + "/files/save?path=" + path,
+            com.microsoft.playwright.options.RequestOptions.create()
+                .setHeader("Content-Type", "application/octet-stream")
+                .setData(content));
+    }
+
+    /**
      * Create a test node by creating its directory and script file
      * Returns true if created successfully
      */

--- a/nodel-webui-js/src/index.xsl
+++ b/nodel-webui-js/src/index.xsl
@@ -529,6 +529,9 @@
                 <input title="<%>desc%>" type="<%>format%>" class="form-control" placeholder="<%>hint%>" data-link="{:<%:~key%>:} id{:~idxid(~idx,'<%:~id%>_field_<%:~key%>')}"/>
               <%else format == 'long'%>
                 <textarea title="<%>desc%>" class="form-control" placeholder="<%>hint%>" data-link="{:<%:~key%>:} id{:~idxid(~idx,'<%:~id%>_field_<%:~key%>')}"></textarea>
+              <%else format == 'cron'%>
+                <input title="<%>desc%>" type="text" autocomplete="off" spellcheck="false" class="form-control nodel-cron" placeholder="<%>hint%>" data-link="{:<%:~key%>:} id{:~idxid(~idx,'<%:~id%>_field_<%:~key%>')}"/>
+                <div class="help-block nodel-cron-feedback"></div>
               <%else%>
                 <input title="<%>desc%>" type="text" class="form-control" placeholder="<%>hint%>" data-link="{:<%:~key%>:} id{:~idxid(~idx,'<%:~id%>_field_<%:~key%>')}"/>
               <%/if%>

--- a/nodel-webui-js/src/nodel.js
+++ b/nodel-webui-js/src/nodel.js
@@ -15,6 +15,13 @@ $.postJSON = function(url, data, callback) {
 
 var counter = 0;
 
+// the app-wide timestamp display format (also registered as the 'nicetime' template helper)
+var nicetime = function (value, precise, format) {
+  if (precise) return moment(value).format('MM-DD HH:mm:ss.SS');
+  if (format) return moment(value).format(format);
+  else return moment(value).format('Do MMM, h:mm a');
+};
+
 $.views.helpers({
   initObj: function (id, value) {
     if(!_.isPlainObject(value)) $.observable(this.data).setProperty(id, {});
@@ -50,11 +57,7 @@ $.views.helpers({
       });
     }
   },
-  nicetime: function (value, precise, format) {
-    if (precise) return moment(value).format('MM-DD HH:mm:ss.SS');
-    if (format) return moment(value).format(format);
-    else return moment(value).format('Do MMM, h:mm a');
-  },
+  nicetime: nicetime,
   fromtime: function(value) {
     now = moment();
     if (typeof(value) == 'string') // treat value as an absolute timestamp
@@ -1206,24 +1209,21 @@ var makeTemplate = function(ele, schema, tmpls){
   //console.log(generatedTemplate);
   $.views.settings.delimiters("{{", "}}");
   var tmpl = $.templates(generatedTemplate);
+  var linkAndResolve = function(data){
+    tmpl.link(ele, data);
+    $(ele).find('.base').addClass('bound');
+    // surface validation and schedule feedback for pre-filled cron fields
+    $(ele).find('input.nodel-cron').each(function () { updateCronFeedback(this); });
+    d.resolve();
+  };
   if(!(_.isUndefined($(ele).data('source'))) && ($(ele).data('source').charAt(0) != '/')){
     // Relative path : $.getJSON(proto+'//'+host+'/nodes/'+encodeURIComponent(node)+'/REST/'+$(ele).data('source'), function(data) {
-    $.getJSON('REST/'+$(ele).data('source'), function(data) {
-      tmpl.link(ele, data);
-      $(ele).find('.base').addClass('bound');
-      d.resolve();
-    });
+    $.getJSON('REST/'+$(ele).data('source'), linkAndResolve);
   } else if(!(_.isUndefined($(ele).data('source'))) && ($(ele).data('source').charAt(0) == '/')){
     // Relative path : $.getJSON(proto+'//'+host+'/nodes/'+encodeURIComponent(node)+'/REST'+$(ele).data('source'), function(data) {
-    $.getJSON('REST'+$(ele).data('source'), function(data) {
-      tmpl.link(ele, data);
-      $(ele).find('.base').addClass('bound');
-      d.resolve();
-    }); 
+    $.getJSON('REST'+$(ele).data('source'), linkAndResolve);
   } else {
-    tmpl.link(ele, {});
-    $(ele).find('.base').addClass('bound');
-    d.resolve();
+    linkAndResolve({});
   }
   return d.promise();
 };
@@ -1280,7 +1280,57 @@ var convertSchemaNames = function(){
   });
 };
 
+// CRON schedule support (schema format 'cron'), shared by the node UI and custom dashboards.
+// The host owns the CRON rules ('REST/cron') so validation, descriptions and execution times
+// cannot drift between consumers. 'timezone' is optional (the host timezone applies); 'onresult'
+// receives {valid, error, description, timeZone, previous, next, upcoming} or null if unreachable.
+var describeCron = function(expression, timezone, onresult) {
+  var query = {'expression': expression};
+  if(timezone) query['timezone'] = timezone;
+  // Relative path : $.getJSON(proto+'//'+host+'/nodes/'+encodeURIComponent(node)+'/REST/cron', query, function(info) {
+  $.getJSON('REST/cron', query, function(info) {
+    onresult(info);
+  }).fail(function() {
+    onresult(null);
+  });
+};
+
+// refreshes the feedback line under a 'format: cron' input (set 'data-timezone' on the
+// input to preview against a specific IANA timezone)
+var updateCronFeedback = function(ele) {
+  var input = $(ele);
+  var group = input.closest('.form-group');
+  var feedback = group.find('.nodel-cron-feedback').first();
+  if(!feedback.length) return;
+  var expression = $.trim(input.val());
+  if(!expression) {
+    group.removeClass('has-error');
+    feedback.empty();
+    return;
+  }
+  describeCron(expression, input.data('timezone'), function(info) {
+    if($.trim(input.val()) !== expression) return; // superseded while in-flight
+    if(!info) return; // host unreachable; leave feedback as-is
+    if(info.valid) {
+      group.removeClass('has-error');
+      var text = info.description ? info.description : '';
+      if(info.next) text += (text ? ' — ' : '') + 'next: ' + nicetime(info.next);
+      feedback.text(text);
+    } else {
+      group.addClass('has-error');
+      feedback.text(info.error ? info.error : 'Invalid CRON expression');
+    }
+  });
+};
+
 var setEvents = function(){
+  $('body').on('input change', 'input.nodel-cron', function () {
+    var ele = this;
+    if(!_.isFunction($(ele).data('cronrefresh'))) {
+      $(ele).data('cronrefresh', _.debounce(function() { updateCronFeedback(ele); }, 300));
+    }
+    $(ele).data('cronrefresh')();
+  });
   $(window).on('resize', function () {
     updatepadding();
   });


### PR DESCRIPTION
Implements museumsvictoria/nodel#411 and restores the `format: "cron"` editor that went missing in the 2.2.x UI rewrite (museumsvictoria/nodel#196). The companion Scheduler recipe is tracked in museumsvictoria/nodel-recipes#108.

The host now owns CRON parsing, validation, descriptions and execution-time calculation in one place (`org.nodel.cron.CronExpressions`, built on cron-utils). Expressions are standard five-field UNIX cron with named weekdays and months, and Sunday accepted as 0 or 7. Schedules run in the host timezone unless given an IANA timezone. The semantics are pinned by tests: occurrences that fall in a daylight-saving gap are skipped, an overlap fires once at the first pass, a fire that arrives late (system suspend, heavy load) happens once with the missed occurrences coalesced into it, and after a restart a schedule looks forward only.

Recipes get a `Cron` class alongside `Timer` with the same lifecycle (starts after `main()`, torn down on script restart), plus `cron_validate`, `cron_describe`, `cron_next` and `cron_previous` helpers. `ManagedCron` self-reschedules one-off tasks on the shared `Timers` pool, so there is no per-schedule thread and no OS scheduler involved.

Every node answers `REST/cron?expression=...&timezone=...` with validity, the failure reason, a readable description and previous/next/upcoming execution times. The web UI renders `format: "cron"` fields as a text input with live, host-backed feedback that also populates for saved values at load; since this ships in the shared v1 bundle, Frontend/Mk2-style dashboards get the same editor with no per-node code.

cron-utils 9.2.1 arrives with its slf4j-api 2.x dependency excluded: the host ships a 1.7-style binding that the 2.x API ignores, so letting it in would silently disable logging. cron-utils only calls 1.7-era logger methods, so it runs safely against the pinned 1.7.10 API.

> [!NOTE]
> The params editor previews execution times in the host timezone. A per-schedule timezone preview needs `data-timezone` on the input, which only hand-written dashboards can set for now.
