### PR TITLE
fix: preserve spacing in nested groups

### DIFF
--- a/nodel-webui-js/src/theme.less
+++ b/nodel-webui-js/src/theme.less
@@ -462,7 +462,7 @@ div.row > div {
   > .btn, > .btn-group, > .btn-group-vertical, > .nav-pills {
     margin-bottom: @form-group-margin-bottom;
   }
-  > .well {
+  .well {
     > .btn, > .btn-group, > .btn-group-vertical, > .nav-pills {
       margin-bottom: @form-group-margin-bottom;
     }


### PR DESCRIPTION
Closes #395; follow-up to #398.

Nested `<group>` controls now keep the same vertical spacing as their top-level counterparts. The spacing rule covers `.well` containers at any group depth while keeping control matching scoped to row columns.