### PR TITLE
fix: encode asterisks in node folder names

### DIFF
--- a/nodel-jyhost/src/main/java/org/nodel/jyhost/NodelHost.java
+++ b/nodel-jyhost/src/main/java/org/nodel/jyhost/NodelHost.java
@@ -706,7 +706,8 @@ public class NodelHost {
                 
             } else {
                 try {
-                    sb.append(URLEncoder.encode(String.valueOf(c), "UTF-8"));
+                    // URLEncoder treats '*' as form-safe, but Windows filenames do not.
+                    sb.append(URLEncoder.encode(String.valueOf(c), "UTF-8").replace("*", "%2A"));
                     
                 } catch (UnsupportedEncodingException e) {
                     throw new RuntimeException("Encoding unexpectedly failed.", e);

--- a/nodel-jyhost/src/test/java/org/nodel/jyhost/NodelHostFilenameEncodingTest.java
+++ b/nodel-jyhost/src/test/java/org/nodel/jyhost/NodelHostFilenameEncodingTest.java
@@ -1,0 +1,21 @@
+package org.nodel.jyhost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.nodel.SimpleName;
+
+class NodelHostFilenameEncodingTest {
+
+    @Test
+    void encodesWindowsReservedCharacters() {
+        assertEquals("%5C%2F%3A%2A%3F%22%3C%3E%7C",
+                NodelHost.encodeIntoSafeFilename(new SimpleName("\\/:*?\"<>|")));
+    }
+
+    @Test
+    void decodesEncodedAndLegacyAsteriskFilenames() {
+        assertEquals("Node*Name", NodelHost.decodeFilenameIntoName("Node%2AName").getOriginalName());
+        assertEquals("Node*Name", NodelHost.decodeFilenameIntoName("Node*Name").getOriginalName());
+    }
+}


### PR DESCRIPTION
Closes #366.

Nodel now encodes asterisks in node folder names as `%2A`, so nodes created or renamed on one operating system can move to Windows without losing their original name. The decoder still accepts existing folders that contain a literal asterisk.

This change does not rename existing literal-asterisk folders.