### PR TITLE
fix: support remote actions/events created at module level on first load

### DIFF
--- a/nodel-framework/src/main/java/org/nodel/host/BaseNode.java
+++ b/nodel-framework/src/main/java/org/nodel/host/BaseNode.java
@@ -638,21 +638,33 @@ public abstract class BaseNode implements Closeable {
     }    
     
     /**
-     * Injects the remote binding values into the Remote Bindings
+     * Fills out any 'gaps' in a config's remote-binding values (nulls in a freshly
+     * constructed or partially hand-edited config), returning the non-null, mutable
+     * structure. Remote actions/events can be created during script execution i.e.
+     * before a node's config has been applied, so lookups must go through here.
      */
-    protected void injectRemoteBindingValues(NodeConfig config, RemoteBindings remoteBindings) {
-        // fill out any 'gaps' in config
+    protected static RemoteBindingValues ensureRemoteBindingValues(NodeConfig config) {
         RemoteBindingValues remoteBindingValues = config.remoteBindingValues;
         if (remoteBindingValues == null) {
             remoteBindingValues = new RemoteBindingValues();
             config.remoteBindingValues = remoteBindingValues;
         }
-        
+
         if (remoteBindingValues.actions == null)
             remoteBindingValues.actions = new LinkedHashMap<SimpleName, RemoteBindingValues.ActionValue>();
         if (remoteBindingValues.events == null)
             remoteBindingValues.events = new LinkedHashMap<SimpleName, RemoteBindingValues.EventValue>();
-        
+
+        return remoteBindingValues;
+    }
+
+    /**
+     * Injects the remote binding values into the Remote Bindings
+     */
+    protected void injectRemoteBindingValues(NodeConfig config, RemoteBindings remoteBindings) {
+        // fill out any 'gaps' in config
+        RemoteBindingValues remoteBindingValues = ensureRemoteBindingValues(config);
+
         // actions
         Map<SimpleName, ActionValue> actionValues = remoteBindingValues.actions;
         if (actionValues != null) {
@@ -847,13 +859,43 @@ public abstract class BaseNode implements Closeable {
     }
 
     /**
+     * Ensures '_bindings' can safely accept remote action/event info entries.
+     * Between loads it can be the shared 'Bindings.Empty' (immutable maps, and
+     * must never be mutated), and remote actions/events can be created during
+     * script execution i.e. before this node's bindings have been extracted
+     * and applied.
+     */
+    private RemoteBindings ensureMutableRemoteBindings() {
+        if (_bindings == Bindings.Empty) {
+            Bindings fresh = new Bindings();
+            // share the sections not written to here
+            fresh.local = Bindings.Empty.local;
+            fresh.params = Bindings.Empty.params;
+            _bindings = fresh;
+        }
+
+        RemoteBindings remote = _bindings.remote;
+        if (remote == null || remote == RemoteBindings.Empty) {
+            remote = new RemoteBindings();
+            _bindings.remote = remote;
+        }
+
+        if (remote.actions == null)
+            remote.actions = new LinkedHashMap<SimpleName, NodelActionInfo>();
+        if (remote.events == null)
+            remote.events = new LinkedHashMap<SimpleName, NodelEventInfo>();
+
+        return remote;
+    }
+
+    /**
      * Add a remote action (by subclass)
      */
     protected void addRemoteAction(NodelClientAction remoteAction, SimpleName suggestedNode, SimpleName suggestedAction) {
         SimpleName remoteActionName = remoteAction.getName();
         
         // look up the value first
-        Map<SimpleName, ActionValue> actionValues = _config.remoteBindingValues.actions;
+        Map<SimpleName, ActionValue> actionValues = ensureRemoteBindingValues(_config).actions;
         ActionValue actionValue = actionValues.get(remoteAction.getName());
         
         SimpleName node = null;
@@ -875,7 +917,7 @@ public abstract class BaseNode implements Closeable {
         }
 
         // ensure a section is already reserved for this remote action
-        Map<SimpleName, NodelActionInfo> remoteActionBindings = _bindings.remote.actions;
+        Map<SimpleName, NodelActionInfo> remoteActionBindings = ensureMutableRemoteBindings().actions;
         
         // (check if same name already being used)
         if (remoteActionBindings.containsKey(remoteActionName))
@@ -902,7 +944,7 @@ public abstract class BaseNode implements Closeable {
         SimpleName remoteEventName = remoteEvent.getName();
         
         // look up the value first
-        Map<SimpleName, EventValue> eventValues = _config.remoteBindingValues.events;
+        Map<SimpleName, EventValue> eventValues = ensureRemoteBindingValues(_config).events;
         EventValue eventValue = eventValues.get(remoteEvent.getName());
         
         SimpleName node = null;
@@ -924,7 +966,7 @@ public abstract class BaseNode implements Closeable {
         }
 
         // ensure a section is already reserved for this remote action
-        Map<SimpleName, NodelEventInfo> remoteEventBindings = _bindings.remote.events;
+        Map<SimpleName, NodelEventInfo> remoteEventBindings = ensureMutableRemoteBindings().events;
         
         // (check if same name already being used)
         if (remoteEventBindings.containsKey(remoteEventName))

--- a/nodel-jyhost/src/main/java/org/nodel/jyhost/PyNode.java
+++ b/nodel-jyhost/src/main/java/org/nodel/jyhost/PyNode.java
@@ -604,7 +604,12 @@ public class PyNode extends BaseDynamicNode {
         Bindings bindings = Bindings.Empty;
         
         List<String> dependenciesUsed = new ArrayList<>(); // holds the dependencies actually used (for logging purposes)
-        
+
+        // remote actions/events created at module level (during script execution)
+        // resolve their binding values through '_config', so the incoming config
+        // must be in place before any script runs
+        _config = config;
+
         try {
             cleanupBindings();
             
@@ -692,8 +697,6 @@ public class PyNode extends BaseDynamicNode {
             injectRemoteBindingValues(config, bindings.remote);
             
             injectParamValues(config, bindings.params);
-            
-            _config = config;
         } catch (Exception exc) {
             hasErrors = true;
             

--- a/nodel-jyhost/src/test/java/org/nodel/ModuleLevelRemoteBindingTests.java
+++ b/nodel-jyhost/src/test/java/org/nodel/ModuleLevelRemoteBindingTests.java
@@ -1,0 +1,89 @@
+package org.nodel;
+
+import com.microsoft.playwright.APIResponse;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for remote events/actions created at module level (the
+ * '@remote_event' decorator or bare 'create_remote_event'/'create_remote_action'
+ * calls), which run during the FIRST execution of a freshly discovered node's
+ * script — before the node's config has been applied. This used to throw a
+ * NullPointerException in BaseNode ('_config.remoteBindingValues' still null)
+ * and abort the script load, taking everything declared after the creation
+ * call with it. Only the first load was affected: a script re-save loads into
+ * an instance whose config has been applied by then, so the failure appeared
+ * only after a (node)host restart.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ModuleLevelRemoteBindingTests extends TestBase {
+
+    private static final String TEST_NODE = "Module Level Remote Binding Test";
+
+    // the 'started' console marker precedes the remote creations so node
+    // discovery succeeds even if the load aborts there; 'MODULE_LEVEL_OK' only
+    // appears if the whole script (including 'main') survived them
+    private static final String SCRIPT =
+        "console.info('Module-level binding node started')\n\n" +
+        "def PduPower(arg):\n" +
+        "    console.info('Power: %s' % arg)\n\n" +
+        "create_remote_event('PduPower', PduPower, {'title': 'PDU power', 'group': 'Power'},\n" +
+        "    suggestedNode='Some PDU', suggestedEvent='Output1')\n\n" +
+        "create_remote_action('PduReboot', {'title': 'PDU reboot', 'group': 'Power'},\n" +
+        "    suggestedNode='Some PDU', suggestedAction='Reboot')\n\n" +
+        "@remote_event({'title': 'PDU power 2', 'group': 'Power'}, suggestedNode='Some PDU', suggestedEvent='Output2')\n" +
+        "def PduPower2(arg):\n" +
+        "    console.info('Power2: %s' % arg)\n\n" +
+        "def main():\n" +
+        "    console.info('MODULE_LEVEL_OK')\n";
+
+    @BeforeAll
+    public static void setup() {
+        initBrowser();
+        // assertTrue, not assumeTrue: failing to initialise on the FIRST load is
+        // the regression itself (the NPE floods the console and discovery times
+        // out), so it must fail the tests rather than skip them
+        assertTrue(createTestNode(TEST_NODE, SCRIPT),
+            "Test node must be created and reach a loaded state on its first load");
+    }
+
+    @AfterAll
+    public static void teardown() {
+        deleteTestNode(TEST_NODE);
+        closeBrowser();
+    }
+
+    @Test
+    @Order(1)
+    public void testScriptLoadsThroughToMain() {
+        assertTrue(waitForConsoleContains(TEST_NODE, "MODULE_LEVEL_OK", 10000),
+            "'main' should run, proving the first script load survived the module-level remote creations");
+    }
+
+    @Test
+    @Order(2)
+    public void testNoLoadErrorsInConsole() {
+        APIResponse response = apiGet("/nodes/" + encode(TEST_NODE) + "/console?from=0&max=100");
+        assertEquals(200, response.status(), "Console endpoint should be available");
+
+        String console = response.text();
+        assertFalse(console.contains("NullPointerException"),
+            "First load must not NPE on module-level remote creations");
+        assertFalse(console.contains("loaded with errors"),
+            "Script should load without errors");
+    }
+
+    @Test
+    @Order(3)
+    public void testRemoteBindingsCreatedWithSuggestions() {
+        APIResponse response = apiGet("/nodes/" + encode(TEST_NODE) + "/remote");
+        assertEquals(200, response.status(), "Remote bindings endpoint should be available");
+
+        String remote = response.text();
+        assertTrue(remote.contains("PduPower"), "Remote event from create_remote_event should exist");
+        assertTrue(remote.contains("PduPower2"), "Remote event from @remote_event decorator should exist");
+        assertTrue(remote.contains("PduReboot"), "Remote action from create_remote_action should exist");
+        assertTrue(remote.contains("Some PDU"), "Suggested node should be pre-filled in the binding values");
+    }
+}


### PR DESCRIPTION
Creating a remote event or action at the top of a script (`create_remote_event`, `create_remote_action`, or the `@remote_event` decorator) crashes the first script load of a node. It throws a `NullPointerException` in `BaseNode.prepareRemoteEvent` and the script stops at that line. Only the first load is affected. Saving the script again loads fine, so a recipe works when written and breaks again on the next host restart. This bit us in production on a BrightSign monitor node.

The cause is ordering in `applyConfig0`. The node's `_config` and `_bindings` are set after the script runs, but creating a remote point reads and writes both while it runs. On a fresh node the config is still null (the NPE), `_bindings` is still the shared read-only `Bindings.Empty`, and the saved binding values are not visible yet, so the point would exist but never wire.

The fix makes each piece safe to touch during the script run. `ensureRemoteBindingValues` fills in a missing config section at the point of use, the same repair `injectRemoteBindingValues` already does. `ensureMutableRemoteBindings` replaces the shared `Bindings.Empty` with a fresh instance instead of writing into it. And `_config = config` now happens before the script runs; a `finally` already set it on every path, so failure behaviour is unchanged. Module-level creation now works the same as creating in `main()`.

The new `ModuleLevelRemoteBindingTests` writes a node folder straight to disk, so discovery does a real first load rather than the re-save path that always worked.

> [!NOTE]
> Not #152. Same "The bindings could not be applied" banner, but that NPE is in cleanup on restart; this one is in creation on first load.
